### PR TITLE
Update podspec homepage

### DIFF
--- a/OmiseGO.podspec
+++ b/OmiseGO.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name = 'OmiseGO'
-  s.version = '0.9.7'
+  s.version = '0.9.8'
   s.license = 'Apache'
   s.summary = 'The OmiseGO iOS SDK allows developers to easily interact with a node of the OmiseGO eWallet.'
-  s.homepage = 'https://omisego.network/'
+  s.homepage = 'https://github.com/omisego/ios-sdk'
   s.social_media_url = 'https://twitter.com/omise_go'
   s.authors = { 'OmiseGO team' => 'omg@omise.co' }
   s.source = { :git => 'https://github.com/omisego/ios-sdk.git', :tag => s.version }

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.7</string>
+	<string>0.9.8</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Issue/Task Number: T854

# Overview

This PR updates the link of the homepage in the Podspec file to point [here](https://github.com/omisego/ios-sdk) instead of the OmiseGO website.

# Changes

- Updated Podspec

# Implementation Details

None

# Usage

No change

# Impact

None.