### PR TITLE
Add metadata to transaction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-OmiseGo Pte Ltd
+Omise Go Ptd. Ltd.

--- a/OmiseGO.podspec
+++ b/OmiseGO.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OmiseGO'
-  s.version = '0.9.8'
+  s.version = '0.9.9'
   s.license = 'Apache'
   s.summary = 'The OmiseGO iOS SDK allows developers to easily interact with a node of the OmiseGO eWallet.'
   s.homepage = 'https://github.com/omisego/ios-sdk'

--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -75,7 +75,7 @@
 		03939D9020286B9E00F65F20 /* TransactionRequestFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03939D8F20286B9E00F65F20 /* TransactionRequestFixtureTests.swift */; };
 		03939D922029672F00F65F20 /* OMGRequestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03939D912029672F00F65F20 /* OMGRequestTest.swift */; };
 		0396627E203FFD6B004E5640 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396627D203FFD6B004E5640 /* Extension.swift */; };
-		03966280203FFF3E004E5640 /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396627F203FFF3E004E5640 /* TransactionTests.swift */; };
+		03966280203FFF3E004E5640 /* TransactionFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396627F203FFF3E004E5640 /* TransactionFixtureTests.swift */; };
 		03966282204005E8004E5640 /* TransactionLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03966281204005E8004E5640 /* TransactionLiveTests.swift */; };
 		0396628420400CE8004E5640 /* TransactionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0396628320400CE8004E5640 /* TransactionTest.swift */; };
 		039DA973203FA72800CCC56A /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039DA972203FA72800CCC56A /* Transaction.swift */; };
@@ -172,7 +172,7 @@
 		03939D8F20286B9E00F65F20 /* TransactionRequestFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRequestFixtureTests.swift; sourceTree = "<group>"; };
 		03939D912029672F00F65F20 /* OMGRequestTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OMGRequestTest.swift; sourceTree = "<group>"; };
 		0396627D203FFD6B004E5640 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
-		0396627F203FFF3E004E5640 /* TransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTests.swift; sourceTree = "<group>"; };
+		0396627F203FFF3E004E5640 /* TransactionFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionFixtureTests.swift; sourceTree = "<group>"; };
 		03966281204005E8004E5640 /* TransactionLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionLiveTests.swift; sourceTree = "<group>"; };
 		0396628320400CE8004E5640 /* TransactionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTest.swift; sourceTree = "<group>"; };
 		039DA972203FA72800CCC56A /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
@@ -271,7 +271,7 @@
 				034FA0431FA31C930033B8D1 /* LogoutFixtureTests.swift */,
 				03939D8F20286B9E00F65F20 /* TransactionRequestFixtureTests.swift */,
 				03FE644D2032AA7400345281 /* TransactionConsumeFixtureTests.swift */,
-				0396627F203FFF3E004E5640 /* TransactionTests.swift */,
+				0396627F203FFF3E004E5640 /* TransactionFixtureTests.swift */,
 				03F5C0101F8CB19D0079E073 /* Fixtures */,
 			);
 			path = FixtureTests;
@@ -656,7 +656,7 @@
 				03CEF4BF1FB012FB009B8CEB /* FixtureClient.swift in Sources */,
 				033522321FB5A7D800BCBD11 /* SettingLiveTests.swift in Sources */,
 				03939D922029672F00F65F20 /* OMGRequestTest.swift in Sources */,
-				03966280203FFF3E004E5640 /* TransactionTests.swift in Sources */,
+				03966280203FFF3E004E5640 /* TransactionFixtureTests.swift in Sources */,
 				03FE64502032C6BF00345281 /* TransactionConsumeTest.swift in Sources */,
 				03A5E8191F8E14570009D5E0 /* ClientTests.swift in Sources */,
 				038CB3E9202B02B300E40715 /* TransactionConsumeParamsTest.swift in Sources */,

--- a/OmiseGOTests/DecodeTests.swift
+++ b/OmiseGOTests/DecodeTests.swift
@@ -295,6 +295,7 @@ class DecodeTests: XCTestCase {
             XCTAssertEqual(decodedData.status, .confirmed)
             XCTAssertEqual(decodedData.createdAt, "2018-01-01T00:00:00Z".toDate())
             XCTAssertEqual(decodedData.updatedAt, "2018-01-01T10:00:00Z".toDate())
+            XCTAssertEqual(decodedData.metadata.count, 0)
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
         }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.list_transactions.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.list_transactions.json
@@ -40,6 +40,7 @@
           "rate": 1
         },
         "status": "confirmed",
+        "metadata": {},
         "created_at": "2018-01-01T00:00:00Z",
         "updated_at": "2018-01-01T10:00:00Z"
         }

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction.json
@@ -34,6 +34,7 @@
     "rate": 1
   },
   "status": "confirmed",
+  "metadata": {},
   "created_at": "2018-01-01T00:00:00Z",
   "updated_at": "2018-01-01T10:00:00Z"
 }

--- a/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
@@ -1,5 +1,5 @@
 //
-//  TransactionTests.swift
+//  TransactionFixtureTests.swift
 //  OmiseGOTests
 //
 //  Created by Mederic Petit on 23/2/18.
@@ -9,8 +9,9 @@
 import XCTest
 import OmiseGO
 
-class TransactionTests: FixtureTestCase {
+class TransactionFixtureTests: FixtureTestCase {
 
+    //swiftlint:disable:next function_body_length
     func testGetListOfTransactions() {
         let expectation =
             self.expectation(description: "Get the list of transactions for the current user")
@@ -47,6 +48,7 @@ class TransactionTests: FixtureTestCase {
                     let exchange = transaction.exchange
                     XCTAssertEqual(exchange.rate, 1)
                     XCTAssertEqual(transaction.status, .confirmed)
+                    XCTAssertEqual(transaction.metadata.count, 0)
                     XCTAssertEqual(transaction.createdAt, "2018-01-01T00:00:00Z".toDate())
                     XCTAssertEqual(transaction.updatedAt, "2018-01-01T10:00:00Z".toDate())
                 case .fail(error: let error):

--- a/OmiseGOTests/Helpers/StubGenerator.swift
+++ b/OmiseGOTests/Helpers/StubGenerator.swift
@@ -120,6 +120,7 @@ class StubGenerator {
         from: TransactionSource? = nil,
         to: TransactionSource? = nil,
         exchange: TransactionExchange? = nil,
+        metadata: [String: Any]? = nil,
         createdAt: Date? = nil,
         updatedAt: Date? = nil)
         -> Transaction {
@@ -130,6 +131,7 @@ class StubGenerator {
                 from: from ?? v.from,
                 to: to ?? v.to,
                 exchange: exchange ?? v.exchange,
+                metadata: metadata ?? v.metadata,
                 createdAt: createdAt ?? v.createdAt,
                 updatedAt: updatedAt ?? v.updatedAt)
     }

--- a/OmiseGOTests/LiveTestCase.swift
+++ b/OmiseGOTests/LiveTestCase.swift
@@ -34,7 +34,7 @@ class LiveTestCase: XCTestCase {
         if !self.areKeysValid() {
             XCTFail("""
                 Missing values for required constants.
-                Replace the in secret.plist or pass them as environment variables.
+                Replace them in secret.plist or pass them as environment variables.
             """)
         }
         self.testClient = OMGClient(config: self.validConfig())

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.8</string>
+	<string>0.9.9</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/Models/Transaction.swift
+++ b/Source/Models/Transaction.swift
@@ -19,15 +19,20 @@ public enum TransactionStatus: String, Decodable {
 }
 
 /// Represents a transaction
-public struct Transaction: Decodable {
+public struct Transaction {
 
     public let id: String
     public let status: TransactionConsumeStatus
     public let from: TransactionSource
     public let to: TransactionSource
     public let exchange: TransactionExchange
+    public let metadata: [String: Any]
     public let createdAt: Date
     public let updatedAt: Date
+
+}
+
+extension Transaction: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -35,8 +40,21 @@ public struct Transaction: Decodable {
         case from
         case to
         case exchange
+        case metadata
         case createdAt = "created_at"
         case updatedAt = "updated_at"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        status = try container.decode(TransactionConsumeStatus.self, forKey: .status)
+        from = try container.decode(TransactionSource.self, forKey: .from)
+        to = try container.decode(TransactionSource.self, forKey: .to)
+        exchange = try container.decode(TransactionExchange.self, forKey: .exchange)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        do {metadata = try container.decode([String: Any].self, forKey: .metadata)} catch {metadata = [:]}
     }
 
 }


### PR DESCRIPTION
# Overview

This PR adds a new metadata field to the `Transaction` object. Indeed, it was possible to add metadata when creating a transaction but we couldn't retrieve it after. [This PR](https://github.com/omisego/ewallet/pull/94) from the `eWallet` repo fixes this.

# Changes

- Add the `metadata: [String: Any]` attribute to `Transaction`.
- Edit the AUTHORS file to use the correct name for OmiseGO.
- Bump version number to 0.9.9
- Rename `TransactionTests` to `TransactionFixtureTests`
