### PR TITLE
Improve linter config

### DIFF
--- a/.swiftlint-test.yml
+++ b/.swiftlint-test.yml
@@ -1,0 +1,12 @@
+included:
+- OmiseGOTests
+line_length: 160
+disabled_rules:
+- identifier_name
+- force_try
+- force_cast
+- cyclomatic_complexity
+- function_body_length
+- type_body_length
+- weak_delegate
+- file_length

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
-excluded:
-- OmiseGOTests
+included:
+- Source
 line_length: 140
 disabled_rules:
 - identifier_name

--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint lint\n    swiftlint lint --config .swiftlint-test.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Issue/Task Number: 150

# Overview

This PR improve the config of swiftlint by separating the linting of the source and the tests.

# Changes

- Modified the root `.swiftlint.yml` to scan only for files in the Source folder.
- Added a new `.swiftlint-test.yml` for config specific to the Tests folder.
- Modified the runtime script to lint both Source and Tests folders.

# Implementation Details

.

# Usage

To lint only the Source folder:
`swiftlint lint`
To lint only the Test folder: 
`swiftlint lint --config .swiftlint-test.yml`

# Impact

None
