### PR TITLE
T196 Add transaction consumption events on transaction request listener

### DIFF
--- a/OmiseGO.podspec
+++ b/OmiseGO.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OmiseGO'
-  s.version = '0.9.10'
+  s.version = '0.9.11'
   s.license = 'Apache'
   s.summary = 'The OmiseGO iOS SDK allows developers to easily interact with a node of the OmiseGO eWallet.'
   s.homepage = 'https://github.com/omisego/ios-sdk'
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.platform = :ios, '10.0'
   s.swift_version = '4.0'
 
-  s.dependency 'Starscream', '~> 3.0.2'
+  s.dependency 'Starscream', '~> 3.0'
 
   s.source_files = 'Source/**/*.swift'
 end

--- a/OmiseGOTests/Helpers/DummySocketEventDelegate.swift
+++ b/OmiseGOTests/Helpers/DummySocketEventDelegate.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class DummySocketEventDelegate {
 
-    let eventExpectation: XCTestExpectation?
+    var eventExpectation: XCTestExpectation?
     let joinExpectation: XCTestExpectation?
 
     init(eventExpectation: XCTestExpectation? = nil, joinExpectation: XCTestExpectation? = nil) {

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ def shared_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
   # websocket library
-  pod 'Starscream', '~> 3.0.2'
+  pod 'Starscream', '~> 3.0'
 end
 
 target 'OmiseGO' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - Starscream (3.0.4)
+  - Starscream (3.0.5)
 
 DEPENDENCIES:
   - Starscream (~> 3.0.2)
 
 SPEC CHECKSUMS:
-  Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
+  Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
 
 PODFILE CHECKSUM: 60bd2f337ffb2f565edc37401613b7b316f33a95
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - Starscream (3.0.5)
 
 DEPENDENCIES:
-  - Starscream (~> 3.0.2)
+  - Starscream (~> 3.0)
 
 SPEC CHECKSUMS:
   Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
 
-PODFILE CHECKSUM: 60bd2f337ffb2f565edc37401613b7b316f33a95
+PODFILE CHECKSUM: b65b55b7361189d8c9b6d31f609db7eba1c61ae8
 
 COCOAPODS: 1.4.0

--- a/README.md
+++ b/README.md
@@ -467,10 +467,21 @@ Where:
 - `client` is a `SocketClient`
 - `eventDelegate` is a `TransactionRequestEventDelegate` that will receive incoming events.
 
-An object conforming to `TransactionRequestEventDelegate` needs to implement the 3 common methods mentioned above and also `didReceiveTransactionConsumptionRequest(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
+An object conforming to `TransactionRequestEventDelegate` needs to implement the 3 common methods mentioned above and also:
+
+- `didReceiveTransactionConsumptionRequest(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
 
 This method will be called when a `TransactionConsumption` is trying to consume the `TransactionRequest`.
 This allows the requester to [confirm](#confirm-a-transaction-consumption) or not the consumption if legitimate.
+
+- `didReceiveTransactionConsumptionApproval(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
+
+If the `TransactionRequest` requires a confirmation then this method will be called when a `TransactionConsumption` is approved by the requester.
+If it doesn't require a confirmation it will be called when the request is consumed.
+
+- `didReceiveTransactionConsumptionRejection(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
+
+This method will be called when a `TransactionConsumption` is rejected by the requester.
 
 
 #### Transaction consumption events
@@ -483,10 +494,15 @@ Where:
 - `client` is a `SocketClient`
 - `eventDelegate` is a `TransactionConsumptionEventDelegate` that will receive incoming events.
 
-An object conforming to `TransactionConsumptionEventDelegate` needs to implement the 3 common methods mentioned above and also `didReceiveTransactionConsumptionConfirmation(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
+An object conforming to `TransactionConsumptionEventDelegate` needs to implement the 3 common methods mentioned above and also:
 
-This method will be called when a `TransactionConsumption` is confirmed by the requester.
+- `didReceiveTransactionConsumptionApproval(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
 
+This method will be called when a `TransactionConsumption` is approved by the requester.
+
+- `didReceiveTransactionConsumptionRejection(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)`.
+
+This method will be called when a `TransactionConsumption` is rejected by the requester.
 
 #### User events
 

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.10</string>
+	<string>0.9.11</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/Websocket/SocketDelegate.swift
+++ b/Source/Websocket/SocketDelegate.swift
@@ -23,6 +23,8 @@ public protocol UserEventDelegate: EventDelegate {
 
 public protocol TransactionRequestEventDelegate: EventDelegate {
     func didReceiveTransactionConsumptionRequest(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)
+    func didReceiveTransactionConsumptionApproval(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)
+    func didReceiveTransactionConsumptionRejection(_ transactionConsumption: TransactionConsumption, forEvent event: SocketEvent)
 }
 
 public protocol TransactionConsumptionEventDelegate: EventDelegate {

--- a/Source/Websocket/SocketDispatcher.swift
+++ b/Source/Websocket/SocketDispatcher.swift
@@ -57,8 +57,16 @@ enum SocketDispatcher {
                                                 payload: GenericObjectEnum,
                                                 event: SocketEvent) {
         switch payload {
-        case .transactionConsumption(object: let transactionConsumption) where event == .transactionConsumptionRequest:
-            handler?.didReceiveTransactionConsumptionRequest(transactionConsumption, forEvent: event)
+        case .transactionConsumption(object: let transactionConsumption):
+            switch event {
+            case .transactionConsumptionRequest:
+                handler?.didReceiveTransactionConsumptionRequest(transactionConsumption, forEvent: event)
+            case .transactionConsumptionApproved:
+                handler?.didReceiveTransactionConsumptionApproval(transactionConsumption, forEvent: event)
+            case .transactionConsumptionRejected:
+                handler?.didReceiveTransactionConsumptionRejection(transactionConsumption, forEvent: event)
+            default: break
+            }
         case .error(error: let error):
             self.dispatchError(error)
         default: break


### PR DESCRIPTION
Issue/Task Number: 196

# Overview

This PR adds 2 missing events when listening for transaction request

# Changes

- Add `transaction_consumption_approved` and `transaction_consumption_rejected` events on transaction request listener.

# Usage

The detailed usage of the events is described in the README.

