### PR TITLE
Fix sync issue with qr code scanner

### DIFF
--- a/OmiseGOTests/QRCodeTests/QRScannerViewModelTest.swift
+++ b/OmiseGOTests/QRCodeTests/QRScannerViewModelTest.swift
@@ -36,22 +36,6 @@ class QRScannerViewModelTest: FixtureTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testCanCallTwiceIfCallSucceeded() {
-        let exp = expectation(description: "Can call with the same id twice if the previous call succeeded")
-        let stub = QRScannerViewModel(client: self.testCustomClient)
-        var counter = 0
-        stub.onGetTransactionRequest = { (transactionRequest) in
-            counter += 1
-            XCTAssert(!stub.loadedIds.contains("123"))
-            XCTAssertNotNil(transactionRequest)
-            if counter == 2 {
-                exp.fulfill()
-            } else { stub.loadTransactionRequest(withId: "123") }
-        }
-        stub.loadTransactionRequest(withId: "123")
-        waitForExpectations(timeout: 1, handler: nil)
-    }
-
     func testCallsOnLoadingStateChangeWhenRequesting() {
         let exp = expectation(description: "Calls onGetTransactionRequest when scanning a valid QRCode")
         let stub = QRScannerViewModel(client: self.testCustomClient)

--- a/Source/QRCode/QRReader.swift
+++ b/Source/QRCode/QRReader.swift
@@ -21,7 +21,7 @@ class QRReader: NSObject {
     init(onFindClosure: @escaping ((String) -> Void)) {
         self.didReadCode = onFindClosure
         super.init()
-        self.sessionQueue.async {
+        self.sessionQueue.sync {
             self.configureReader()
         }
     }
@@ -41,14 +41,14 @@ class QRReader: NSObject {
     }
 
     func startScanning() {
-        self.sessionQueue.async {
+        self.sessionQueue.sync {
             guard !self.session.isRunning else { return }
             self.session.startRunning()
         }
     }
 
     func stopScanning() {
-        self.sessionQueue.async {
+        self.sessionQueue.sync {
             guard self.session.isRunning else { return }
             self.session.stopRunning()
         }
@@ -66,7 +66,7 @@ extension QRReader: AVCaptureMetadataOutputObjectsDelegate {
     func metadataOutput(_ output: AVCaptureMetadataOutput,
                         didOutput metadataObjects: [AVMetadataObject],
                         from connection: AVCaptureConnection) {
-        self.sessionQueue.async { [weak self] in
+        self.sessionQueue.sync { [weak self] in
             guard let weakSelf = self else { return }
             guard !metadataObjects.isEmpty,
                 let metadataObject = metadataObjects[0] as? AVMetadataMachineReadableCodeObject,

--- a/Source/QRCode/QRReader.swift
+++ b/Source/QRCode/QRReader.swift
@@ -16,12 +16,12 @@ class QRReader: NSObject {
     lazy var previewLayer: AVCaptureVideoPreviewLayer = {
         return AVCaptureVideoPreviewLayer(session: self.session)
     }()
-    private let sessionQueue: DispatchQueue = DispatchQueue(label: "io.omisego.qrqueue")
+    private let sessionQueue: DispatchQueue = DispatchQueue(label: "serial queue")
 
     init(onFindClosure: @escaping ((String) -> Void)) {
         self.didReadCode = onFindClosure
         super.init()
-        self.sessionQueue.sync {
+        self.sessionQueue.async {
             self.configureReader()
         }
     }
@@ -41,14 +41,14 @@ class QRReader: NSObject {
     }
 
     func startScanning() {
-        self.sessionQueue.sync {
+        self.sessionQueue.async {
             guard !self.session.isRunning else { return }
             self.session.startRunning()
         }
     }
 
     func stopScanning() {
-        self.sessionQueue.sync {
+        self.sessionQueue.async {
             guard self.session.isRunning else { return }
             self.session.stopRunning()
         }
@@ -66,7 +66,7 @@ extension QRReader: AVCaptureMetadataOutputObjectsDelegate {
     func metadataOutput(_ output: AVCaptureMetadataOutput,
                         didOutput metadataObjects: [AVMetadataObject],
                         from connection: AVCaptureConnection) {
-        self.sessionQueue.sync { [weak self] in
+        self.sessionQueue.async { [weak self] in
             guard let weakSelf = self else { return }
             guard !metadataObjects.isEmpty,
                 let metadataObject = metadataObjects[0] as? AVMetadataMachineReadableCodeObject,

--- a/Source/QRCode/QRScannerViewModel.swift
+++ b/Source/QRCode/QRScannerViewModel.swift
@@ -53,12 +53,9 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
         self.stopScanning()
         self.onLoadingStateChange?(true)
         TransactionRequest.retrieveTransactionRequest(using: self.client, id: id) { (result) in
-            self.startScanning()
             self.onLoadingStateChange?(false)
             switch result {
             case .success(data: let transactionRequest):
-                // Allows to scan the same id again only if was valid
-                if let index = self.loadedIds.index(of: id) { self.loadedIds.remove(at: index) }
                 self.onGetTransactionRequest?(transactionRequest)
             case .fail(error: let error): self.onError?(error)
             }

--- a/Source/QRCode/QRScannerViewModel.swift
+++ b/Source/QRCode/QRScannerViewModel.swift
@@ -57,7 +57,9 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
             switch result {
             case .success(data: let transactionRequest):
                 self.onGetTransactionRequest?(transactionRequest)
-            case .fail(error: let error): self.onError?(error)
+            case .fail(error: let error):
+                self.startScanning()
+                self.onError?(error)
             }
         }
     }


### PR DESCRIPTION
Issue/Task Number: 197

# Overview

This PR fixes an issue with the QRCode scanner where the scanner could sometimes be started again after being stoped because of threading issues.

# Changes

- Change from `async` dispatch to `sync`, so if we first ask the QRCode to start scanning then stop scanning, it will always do the start then the stop, and not in a random order.