### PR TITLE
Fix can't pass nil for amount in consumption params

### DIFF
--- a/OmiseGOTests/CodingTests/EncodeTests.swift
+++ b/OmiseGOTests/CodingTests/EncodeTests.swift
@@ -236,7 +236,7 @@ class EncodeTests: XCTestCase {
         }
     }
 
-    func testTransactionConsumptionParamsEncoding() {
+    func testTransactionConsumptionParamsWithoutAmountEncoding() {
         do {
             let transactionRequest = TransactionRequest(id: "0a8a4a98-794b-419e-b92d-514e83657e75",
                                                         type: .receive,
@@ -257,6 +257,7 @@ class EncodeTests: XCTestCase {
             let transactionConsumptionParams = TransactionConsumptionParams(transactionRequest: transactionRequest,
                                                                             address: "456",
                                                                             mintedTokenId: "BTC:123",
+                                                                            amount: nil,
                                                                             idempotencyToken: "123",
                                                                             correlationId: "321",
                                                                             expirationDate: Date(timeIntervalSince1970: 0),
@@ -266,7 +267,7 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "amount":1337,
+                    "amount":null,
                     "transaction_request_id":"0a8a4a98-794b-419e-b92d-514e83657e75",
                     "metadata":{},
                     "token_id":"BTC:123",

--- a/OmiseGOTests/FixtureTests/TransactionConsumptionFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionConsumptionFixtureTests.swift
@@ -26,6 +26,7 @@ class TransactionConsumptionFixtureTests: FixtureTestCase {
                 transactionRequest: transactionRequest,
                 address: nil,
                 mintedTokenId: nil,
+                amount: nil,
                 idempotencyToken: "123",
                 correlationId: nil,
                 expirationDate: nil,

--- a/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
+++ b/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
@@ -17,6 +17,7 @@ class TransactionConsumptionParamsTest: XCTestCase {
         XCTAssertNotNil(TransactionConsumptionParams(transactionRequest: transactionRequest,
                                                      address: nil,
                                                      mintedTokenId: nil,
+                                                     amount: nil,
                                                      idempotencyToken: "123",
                                                      correlationId: nil,
                                                      expirationDate: Date(timeIntervalSince1970: 0),
@@ -43,13 +44,14 @@ class TransactionConsumptionParamsTest: XCTestCase {
         XCTAssertNil(TransactionConsumptionParams(transactionRequest: transactionRequest,
                                                   address: nil,
                                                   mintedTokenId: nil,
+                                                  amount: nil,
                                                   idempotencyToken: "123",
                                                   correlationId: nil,
                                                   expirationDate: nil,
                                                   metadata: [:]))
     }
 
-    func testAmountIsTakenFromParamsIfTransactionRequestAmountIsNil() {
+    func testInitCorrectlyWhenGivenAnAmount() {
         let transactionRequest = TransactionRequest(id: "0a8a4a98-794b-419e-b92d-514e83657e75",
                                                     type: .receive,
                                                     mintedToken: StubGenerator.mintedToken(),

--- a/Source/Models/TransactionConsumptionParams.swift
+++ b/Source/Models/TransactionConsumptionParams.swift
@@ -12,7 +12,7 @@ public struct TransactionConsumptionParams {
     /// The id of the transaction request to be consumed
     public let transactionRequestId: String
     /// The amount of minted token to transfer (down to subunit to unit)
-    public let amount: Double
+    public let amount: Double?
     /// The address to use for the consumption
     public let address: String?
     /// The id of the minted token to use for the request
@@ -45,12 +45,12 @@ public struct TransactionConsumptionParams {
     public init?(transactionRequest: TransactionRequest,
                  address: String?,
                  mintedTokenId: String?,
-                 amount: Double? = nil,
+                 amount: Double?,
                  idempotencyToken: String,
                  correlationId: String?,
                  expirationDate: Date?,
                  metadata: [String: Any]) {
-        guard let amount = (amount != nil ? amount : transactionRequest.amount) else { return nil }
+        guard transactionRequest.amount != nil || amount != nil else { return nil }
         self.transactionRequestId = transactionRequest.id
         self.amount = amount
         self.address = address


### PR DESCRIPTION
Issue/Task Number: 203

# Overview

This PR fixes an issue where we couldn't pass nil for amount in consumption params and caused the consumption to fail if the `allow_amount_override` is `false`.

# Changes

- Allow passed amount to be `nil` if the `transactionRequest.amount` is not `nil`
