### PR TITLE
T209 update transaction request and consumption params

### DIFF
--- a/OmiseGOTests/CodingTests/EncodeTests.swift
+++ b/OmiseGOTests/CodingTests/EncodeTests.swift
@@ -260,7 +260,6 @@ class EncodeTests: XCTestCase {
                                                                             amount: nil,
                                                                             idempotencyToken: "123",
                                                                             correlationId: "321",
-                                                                            expirationDate: Date(timeIntervalSince1970: 0),
                                                                             metadata: [:])
             let encodedData = try self.encoder.encode(transactionConsumptionParams)
             let encodedPayload = try! transactionConsumptionParams!.encodedPayload()

--- a/OmiseGOTests/FixtureTests/TransactionConsumptionFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionConsumptionFixtureTests.swift
@@ -29,7 +29,6 @@ class TransactionConsumptionFixtureTests: FixtureTestCase {
                 amount: nil,
                 idempotencyToken: "123",
                 correlationId: nil,
-                expirationDate: nil,
                 metadata: [:])!
         let request =
             TransactionConsumption.consumeTransactionRequest(using: self.testCustomClient, params: params) { (result) in

--- a/OmiseGOTests/Helpers/StubGenerator.swift
+++ b/OmiseGOTests/Helpers/StubGenerator.swift
@@ -256,7 +256,6 @@ class StubGenerator {
             amount: amount,
             idempotencyToken: idempotencyToken,
             correlationId: correlationId,
-            expirationDate: expirationDate,
             metadata: metadata
             )!
     }

--- a/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
+++ b/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
@@ -198,7 +198,6 @@ extension TransactionRequestLiveTests {
             amount: nil,
             idempotencyToken: idempotencyToken,
             correlationId: consumeCorrelationId,
-            expirationDate: nil,
             metadata: ["a_key": "a_value"])
         var transactionConsumptionResult: TransactionConsumption?
         let consumeRequest = TransactionConsumption.consumeTransactionRequest(

--- a/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
+++ b/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
@@ -20,7 +20,6 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                      amount: nil,
                                                      idempotencyToken: "123",
                                                      correlationId: nil,
-                                                     expirationDate: Date(timeIntervalSince1970: 0),
                                                      metadata: [:]))
     }
 
@@ -47,7 +46,6 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                   amount: nil,
                                                   idempotencyToken: "123",
                                                   correlationId: nil,
-                                                  expirationDate: nil,
                                                   metadata: [:]))
     }
 
@@ -74,7 +72,6 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                               amount: 3000,
                                               idempotencyToken: "123",
                                               correlationId: nil,
-                                              expirationDate: nil,
                                               metadata: [:])!
         XCTAssertEqual(params.amount, 3000)
     }
@@ -87,7 +84,6 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                   amount: 3000,
                                                   idempotencyToken: "123",
                                                   correlationId: nil,
-                                                  expirationDate: nil,
                                                   metadata: [:])!
         XCTAssertEqual(params.amount, 3000)
     }

--- a/README.md
+++ b/README.md
@@ -320,7 +320,6 @@ guard let params = TransactionConsumptionParams(transactionRequest: transactionR
                                                 mintedTokenId: "a minted token",
                                                 amount: 1337,
                                                 idempotencyToken: "an idempotency token",
-                                                expirationDate: nil,
                                                 correlationId: "a correlation id",
                                                 metadata: [:])!
 TransactionConsumption.consumeTransactionRequest(using: client, params: params) { (transactionConsumptionResult) in
@@ -342,7 +341,6 @@ Where `params` is a `TransactionConsumptionParams` struct constructed using:
 > Note that if the `amount` was not specified in the transaction request it needs to be specified here, otherwise the init will fail and return `nil`.
 
 - `idempotencyToken`: The idempotency token used to ensure that the transaction will be executed one time only on the server. If the network call fails, you should reuse the same `idempotencyToken` when retrying the request.
-- `expirationDate`: (optional) The date when the consumption will expire.
 - `correlationId`: (optional) An id that can uniquely identify a transaction. Typically an order id from a provider.
 - `metadata`: A dictionary of additional data to be stored for this transaction consumption.
 

--- a/Source/Models/TransactionConsumptionParams.swift
+++ b/Source/Models/TransactionConsumptionParams.swift
@@ -23,8 +23,6 @@ public struct TransactionConsumptionParams {
     public let idempotencyToken: String
     /// An id that can uniquely identify a transaction. Typically an order id from a provider.
     public let correlationId: String?
-    /// The date when the consumption will expire
-    public let expirationDate: Date?
     /// Additional metadata for the consumption
     public let metadata: [String: Any]
 
@@ -40,7 +38,6 @@ public struct TransactionConsumptionParams {
     ///   - amount: The amount of minted token to transfer (down to subunit to unit)
     ///   - idempotencyToken: The idempotency token to use for the consumption
     ///   - correlationId: An id that can uniquely identify a transaction. Typically an order id from a provider.
-    ///   - expirationDate: The date when the consumption will expire
     ///   - metadata: Additional metadata for the consumption
     public init?(transactionRequest: TransactionRequest,
                  address: String?,
@@ -48,7 +45,6 @@ public struct TransactionConsumptionParams {
                  amount: Double?,
                  idempotencyToken: String,
                  correlationId: String?,
-                 expirationDate: Date?,
                  metadata: [String: Any]) {
         guard transactionRequest.amount != nil || amount != nil else { return nil }
         self.transactionRequestId = transactionRequest.id
@@ -57,7 +53,6 @@ public struct TransactionConsumptionParams {
         self.mintedTokenId = mintedTokenId
         self.idempotencyToken = idempotencyToken
         self.correlationId = correlationId
-        self.expirationDate = expirationDate
         self.metadata = metadata
     }
 

--- a/Source/Models/TransactionRequest.swift
+++ b/Source/Models/TransactionRequest.swift
@@ -39,7 +39,7 @@ public struct TransactionRequest {
     /// This amount needs to be either specified by the requester or the consumer
     public let amount: Double?
     /// The address from which to send or receive the minted tokens
-    public let address: String?
+    public let address: String
     /// An id that can uniquely identify a transaction. Typically an order id from a provider.
     public let correlationId: String?
     /// The status of the request (valid or expired)
@@ -94,7 +94,7 @@ extension TransactionRequest: Decodable {
         type = try container.decode(TransactionRequestType.self, forKey: .type)
         mintedToken = try container.decode(MintedToken.self, forKey: .mintedToken)
         amount = try container.decodeIfPresent(Double.self, forKey: .amount)
-        address = try container.decodeIfPresent(String.self, forKey: .address)
+        address = try container.decode(String.self, forKey: .address)
         correlationId = try container.decodeIfPresent(String.self, forKey: .correlationId)
         status = try container.decode(TransactionRequestStatus.self, forKey: .status)
         socketTopic = try container.decode(String.self, forKey: .socketTopic)


### PR DESCRIPTION
Issue/Task Number: 209

# Overview

This PR adjusts the params for `TransactionRequest` and `TransactionConsumptionParams`

# Changes

- Make address not optional in `TransactionRequest`
- Remove `expirationDate` from `TransactionConsumptionParams`

