### PR TITLE
T160 update pagination params

### DIFF
--- a/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
@@ -18,7 +18,6 @@ class TransactionFixtureTests: FixtureTestCase {
         let paginationParams = PaginationParams<Transaction>(page: 1,
                                                              perPage: 10,
                                                              searchTerm: nil,
-                                                             searchTerms: nil,
                                                              sortBy: .to,
                                                              sortDirection: .ascending)
         let params = TransactionListParams(paginationParams: paginationParams, address: nil)

--- a/OmiseGOTests/LiveTests/TransactionLiveTests.swift
+++ b/OmiseGOTests/LiveTests/TransactionLiveTests.swift
@@ -17,7 +17,6 @@ class TransactionLiveTests: LiveTestCase {
             page: 1,
             perPage: 10,
             searchTerm: nil,
-            searchTerms: nil,
             sortBy: .createdAt,
             sortDirection: .descending)
         let params = TransactionListParams(paginationParams: paginationParams, address: nil)

--- a/Source/Models/PaginationParams.swift
+++ b/Source/Models/PaginationParams.swift
@@ -42,27 +42,50 @@ public struct PaginationParams<T: Paginable> {
     /// The sort direction (ascending or descending)
     public let sortDirection: SortDirection
 
-    /// Initialize the params used to query a paginated collection
-    ///
-    /// - Parameters:
-    ///   - page: The page requested (0 and 1 are the same)
-    ///   - perPage: The number of result expected per page
-    ///   - searchTerm: The global search term used to search in any of the SearchableFields
-    ///   - searchTerms: A dictionary where each key is a Searchable field that and each value is a search term
-    ///   - sortBy: The field to sort by
-    ///   - sortDirection: The sort direction (ascending or descending)
-    public init(page: Int,
-                perPage: Int,
-                searchTerm: String?,
-                searchTerms: [T.SearchableFields: Any]?,
-                sortBy: T.SortableFields,
-                sortDirection: SortDirection) {
+    init(page: Int,
+         perPage: Int,
+         searchTerm: String?,
+         searchTerms: [T.SearchableFields: Any]?,
+         sortBy: T.SortableFields,
+         sortDirection: SortDirection) {
         self.page = page
         self.perPage = perPage
         self.searchTerm = searchTerm
         self.searchTerms = searchTerms
         self.sortBy = sortBy
         self.sortDirection = sortDirection
+    }
+
+    /// Initialize the params used to query a paginated collection
+    ///
+    /// - Parameters:
+    ///   - page: The page requested (0 and 1 are the same)
+    ///   - perPage: The number of result expected per page
+    ///   - searchTerm: The global search term used to search in any of the SearchableFields
+    ///   - sortBy: The field to sort by
+    ///   - sortDirection: The sort direction (ascending or descending)
+    public init(page: Int,
+                perPage: Int,
+                searchTerm: String?,
+                sortBy: T.SortableFields,
+                sortDirection: SortDirection) {
+        self.init(page: page, perPage: perPage, searchTerm: searchTerm, searchTerms: nil, sortBy: sortBy, sortDirection: sortDirection)
+    }
+
+    /// Initialize the params used to query a paginated collection
+    ///
+    /// - Parameters:
+    ///   - page: The page requested (0 and 1 are the same)
+    ///   - perPage: The number of result expected per page
+    ///   - searchTerms: A dictionary where each key is a Searchable field that and each value is a search term
+    ///   - sortBy: The field to sort by
+    ///   - sortDirection: The sort direction (ascending or descending)
+    public init(page: Int,
+                perPage: Int,
+                searchTerms: [T.SearchableFields: Any]?,
+                sortBy: T.SortableFields,
+                sortDirection: SortDirection) {
+        self.init(page: page, perPage: perPage, searchTerm: nil, searchTerms: searchTerms, sortBy: sortBy, sortDirection: sortDirection)
     }
 
 }

--- a/Source/Websocket/SocketEvent.swift
+++ b/Source/Websocket/SocketEvent.swift
@@ -10,12 +10,12 @@ enum SocketEventSend: String, Encodable {
     case heartbeat = "heartbeat"
     case join = "phx_join"
     case leave = "phx_leave"
-    case error = "phx_error"
-    case close = "phx_close"
 }
 
 public enum SocketEvent: Decodable {
     case reply
+    case error
+    case close
     case transactionConsumptionRequest
     case transactionConsumptionFinalized
     case other(event: String)
@@ -37,6 +37,8 @@ extension SocketEvent: RawRepresentable {
 
     public init?(rawValue: String) {
         switch rawValue {
+        case "phx_error": self = .error
+        case "phx_close": self = .close
         case "phx_reply": self = .reply
         case "transaction_consumption_request": self = .transactionConsumptionRequest
         case "transaction_consumption_finalized": self = .transactionConsumptionFinalized
@@ -46,6 +48,8 @@ extension SocketEvent: RawRepresentable {
 
     public var rawValue: String {
         switch self {
+        case .error: return "phx_error"
+        case .close: return "phx_close"
         case .reply: return "phx_reply"
         case .transactionConsumptionRequest: return "transaction_consumption_request"
         case .transactionConsumptionFinalized: return "transaction_consumption_finalized"


### PR DESCRIPTION
Issue/Task Number: 160

# Overview

This PR split the `init` of the pagination params in order to avoid confusion as `searchTerm` and `searchTerms` can't work together.

# Changes

- Split init
- Update socket events
