### PR TITLE
T259 improve log

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ You should do this as soon as you obtain a valid authentication token correspond
 ```swift
 let configuration = ClientConfiguration(baseURL: "https://your.base.url/api",
                                         apiKey: "apiKey",
-                                        authenticationToken: "authenticationToken")
+                                        authenticationToken: "authenticationToken",
+                                        debugLog: false)
 let client = HTTPClient(config: configuration)
 ```
 
@@ -132,6 +133,8 @@ Where:
 - `apiKey` is the API key (typically generated on the admin panel)
 - `authenticationToken` is the token corresponding to an OmiseGO Wallet user retrievable using one of our server-side SDKs.
 > You can find more info on how to retrieve this token in the [OmiseGO server SDK documentations](https://github.com/omisego/ruby-sdk#login).
+
+- `debugLog` is a boolean indicating if the SDK should print logs in the console.
 
 ### Retrieving resources
 
@@ -441,7 +444,8 @@ Similarly to the HTTP client, the `SocketClient` needs to be first initialized  
 ```swift
 let configuration = ClientConfiguration(baseURL: "wss://your.base.url/api/socket",
                                         apiKey: "apiKey",
-                                        authenticationToken: "authenticationToken")
+                                        authenticationToken: "authenticationToken",
+                                        debugLog: false)
 let client = SocketClient(config: configuration, delegate: self)
 ```
 
@@ -450,6 +454,8 @@ Where:
 - `apiKey` is the API key (typically generated on the admin panel)
 - `authenticationToken` is the token corresponding to an OmiseGO Wallet user retrievable using one of our server-side SDKs.
 > You can find more info on how to retrieve this token in the [OmiseGO server SDK documentations](https://github.com/omisego/ruby-sdk#login).
+
+- `debugLog` is a boolean indicating if the SDK should print logs in the console.
 
 ### Listenable resources
 

--- a/Source/API/ClientConfiguration.swift
+++ b/Source/API/ClientConfiguration.swift
@@ -20,6 +20,8 @@ public struct ClientConfiguration {
     public let apiKey: String
     /// The authentication token of the current user
     public var authenticationToken: String?
+    /// A boolean indicating if debug info should be printed in the console
+    let debugLog: Bool
 
     /// Creates the configuration required to initialize the OmiseGO SDK
     ///
@@ -29,10 +31,12 @@ public struct ClientConfiguration {
     ///              When initializing the SocketClient, this needs to be a ws(s) url
     ///   - apiKey: The API key (typically generated on the admin panel)
     ///   - authenticationToken: The authentication token of the current user
-    public init(baseURL: String, apiKey: String, authenticationToken: String) {
+    ///   - debugLog: Enable or not SDK console logs
+    public init(baseURL: String, apiKey: String, authenticationToken: String, debugLog: Bool = false) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.authenticationToken = authenticationToken
+        self.debugLog = debugLog
     }
 
 }

--- a/Source/API/Request.swift
+++ b/Source/API/Request.swift
@@ -64,6 +64,9 @@ public class Request<ResultType: Decodable> {
             return .fail(error: .unexpected(message: "unrecognized HTTP status code: \(statusCode)"))
         }
         do {
+            if self.client.config.debugLog {
+                omiseGOInfo("Did receive: \(String(data: data, encoding: .utf8) ?? "")")
+            }
             let response: JSONResponse<ResultType> = try deserializeData(data)
             return response.data
         } catch let error {

--- a/Source/Websocket/SocketClient.swift
+++ b/Source/Websocket/SocketClient.swift
@@ -214,7 +214,9 @@ extension SocketClient: WebSocketDelegate {
     }
 
     public func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
-        omiseGOInfo("websockets did receive: \(text)")
+        if let config = self.config, config.debugLog {
+            omiseGOInfo("websockets did receive: \(text)")
+        }
         guard let data = text.data(using: .utf8), let payload: SocketPayloadReceive = try? deserializeData(data) else { return }
         var message: SocketMessage!
         if let ref = payload.ref, let waitingForResponse = self.awaitingResponse[ref] {


### PR DESCRIPTION
Issue/Task Number: 259

# Overview

This PR adds a flag when initializing the clients which enable or disable request logs.

# Changes

- Add `debugLog` flag in config (default to false)
- Only print logs if `debugLog` is `true`

# Usage

When initializing a client (http or web socket), set the flag `debugLog` to true to have the logs printed in the console.

# Impact

None