### PR TITLE
Remove updatedAt from transactions

### DIFF
--- a/OmiseGOTests/CodingTests/DecodeTests.swift
+++ b/OmiseGOTests/CodingTests/DecodeTests.swift
@@ -385,7 +385,6 @@ class DecodeTests: XCTestCase {
             XCTAssertEqual(exchange.rate, 1)
             XCTAssertEqual(decodedData.status, .confirmed)
             XCTAssertEqual(decodedData.createdAt, "2018-01-01T00:00:00Z".toDate(withFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
-            XCTAssertEqual(decodedData.updatedAt, "2018-01-01T10:00:00Z".toDate(withFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
             XCTAssertTrue(decodedData.metadata.isEmpty)
             XCTAssertTrue(decodedData.encryptedMetadata.isEmpty)
         } catch let thrownError {

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.approve_transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.approve_transaction_consumption.json
@@ -61,8 +61,7 @@
       "metadata": {},
       "encrypted_metadata": {},
       "status": "confirmed",
-      "created_at": "2018-01-01T00:00:00Z",
-      "updated_at": "2018-01-01T10:00:00Z"
+      "created_at": "2018-01-01T00:00:00Z"
     },
     "transaction_request": {
       "object": "transaction_request",

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.consume_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.consume_transaction_request.json
@@ -61,8 +61,7 @@
       "metadata": {},
       "encrypted_metadata": {},
       "status": "confirmed",
-      "created_at": "2018-01-01T00:00:00Z",
-      "updated_at": "2018-01-01T10:00:00Z"
+      "created_at": "2018-01-01T00:00:00Z"
     },
     "transaction_request": {
       "object": "transaction_request",

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.list_transactions.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.list_transactions.json
@@ -46,8 +46,7 @@
         "status": "confirmed",
         "metadata": {},
         "encrypted_metadata": {},
-        "created_at": "2018-01-01T00:00:00Z",
-        "updated_at": "2018-01-01T10:00:00Z"
+        "created_at": "2018-01-01T00:00:00Z"
         }
 
     ],

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.reject_transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.reject_transaction_consumption.json
@@ -61,8 +61,7 @@
       "metadata": {},
       "encrypted_metadata": {},
       "status": "confirmed",
-      "created_at": "2018-01-01T00:00:00Z",
-      "updated_at": "2018-01-01T10:00:00Z"
+      "created_at": "2018-01-01T00:00:00Z"
     },
     "transaction_request": {
       "object": "transaction_request",

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/socket_response.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/socket_response.json
@@ -65,8 +65,7 @@
       "metadata": {},
       "encrypted_metadata": {},
       "status": "confirmed",
-      "created_at": "2018-01-01T00:00:00Z",
-      "updated_at": "2018-01-01T10:00:00Z"
+      "created_at": "2018-01-01T00:00:00Z"
     },
     "transaction_request": {
       "object": "transaction_request",

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction.json
@@ -40,6 +40,5 @@
   "status": "confirmed",
   "metadata": {},
   "encrypted_metadata": {},
-  "created_at": "2018-01-01T00:00:00Z",
-  "updated_at": "2018-01-01T10:00:00Z"
+  "created_at": "2018-01-01T00:00:00Z"
 }

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_consumption.json
@@ -58,8 +58,7 @@
     "metadata": {},
     "encrypted_metadata": {},
     "status": "confirmed",
-    "created_at": "2018-01-01T00:00:00Z",
-    "updated_at": "2018-01-01T10:00:00Z"
+    "created_at": "2018-01-01T00:00:00Z"
   },
   "transaction_request": {
     "object": "transaction_request",

--- a/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
@@ -50,7 +50,6 @@ class TransactionFixtureTests: FixtureTestCase {
                     XCTAssertTrue(transaction.metadata.isEmpty)
                     XCTAssertTrue(transaction.encryptedMetadata.isEmpty)
                     XCTAssertEqual(transaction.createdAt, "2018-01-01T00:00:00Z".toDate())
-                    XCTAssertEqual(transaction.updatedAt, "2018-01-01T10:00:00Z".toDate())
                 case .fail(error: let error):
                     XCTFail("\(error)")
                 }

--- a/OmiseGOTests/Helpers/StubGenerator.swift
+++ b/OmiseGOTests/Helpers/StubGenerator.swift
@@ -187,8 +187,7 @@ class StubGenerator {
         exchange: TransactionExchange? = nil,
         metadata: [String: Any]? = nil,
         encryptedMetadata: [String: Any]? = nil,
-        createdAt: Date? = nil,
-        updatedAt: Date? = nil)
+        createdAt: Date? = nil)
         -> Transaction {
             let v: Transaction = self.stub(forResource: "transaction")
             return Transaction(
@@ -199,8 +198,7 @@ class StubGenerator {
                 exchange: exchange ?? v.exchange,
                 metadata: metadata ?? v.metadata,
                 encryptedMetadata: encryptedMetadata ?? v.encryptedMetadata,
-                createdAt: createdAt ?? v.createdAt,
-                updatedAt: updatedAt ?? v.updatedAt)
+                createdAt: createdAt ?? v.createdAt)
     }
 
     class func transactionSource(

--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ let paginationParams = PaginationParams<Transaction>(
 Where:
 - `page` is the page you wish to receive.
 - `perPage` is the number of results per page.
-- `sortBy` is the sorting field. Available values: `.id`, `.status`, `.from`, `.to`, `.createdAt`, `.updatedAt`
+- `sortBy` is the sorting field. Available values: `.id`, `.status`, `.from`, `.to`, `.createdAt`
 - `sortDir` is the sorting direction. Available values: `.ascending`, `.descending`
 - `searchTerm` is a term to search for in ALL of the searchable fields. Conflict with search_terms, only use one of them. See list of searchable fields below (same as search_terms).
-- `searchTerms` is a dictionary of fields to search in with the following available fields: `.id`, `.status`, `.from`, `.to`, `.createdAt`, `.updatedAt`. Ex: `[.from: "someAddress", .id: "someId"]`
+- `searchTerms` is a dictionary of fields to search in with the following available fields: `.id`, `.status`, `.from`, `.to`. Ex: `[.from: "someAddress", .id: "someId"]`
 
 Then you can call:
 

--- a/Source/Models/Transaction.swift
+++ b/Source/Models/Transaction.swift
@@ -36,8 +36,6 @@ public struct Transaction {
     public let encryptedMetadata: [String: Any]
     /// The creation date of the transaction
     public let createdAt: Date
-    /// The last update date of the transaction
-    public let updatedAt: Date
 
 }
 
@@ -52,7 +50,6 @@ extension Transaction: Decodable {
         case metadata
         case encryptedMetadata = "encrypted_metadata"
         case createdAt = "created_at"
-        case updatedAt = "updated_at"
     }
 
     public init(from decoder: Decoder) throws {
@@ -63,7 +60,6 @@ extension Transaction: Decodable {
         to = try container.decode(TransactionSource.self, forKey: .to)
         exchange = try container.decode(TransactionExchange.self, forKey: .exchange)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
-        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         metadata = try container.decode([String: Any].self, forKey: .metadata)
         encryptedMetadata = try container.decode([String: Any].self, forKey: .encryptedMetadata)
     }
@@ -104,7 +100,6 @@ extension Transaction: Paginable {
         case from
         case to
         case createdAt = "created_at"
-        case updatedAt = "updated_at"
     }
 
 }


### PR DESCRIPTION
Issue/Task Number: 282

# Overview

This PR removes the `updatedAt`attribute and its related uses from `Transaction`.

# Changes

- Remove `updatedAt` attribute from `Transaction` model
- Update the sort/filter terms of `Transaction` 

# Implementation Details

Transaction can't be updated so there is no need for the `updatedAt` attribute.

# Impact

Once removed from the API, older version of the SDK will not work anymore.
