### PR TITLE
T281 max consumption per user

### DIFF
--- a/OmiseGOTests/APITests/APIErrorTests.swift
+++ b/OmiseGOTests/APITests/APIErrorTests.swift
@@ -59,10 +59,12 @@ class APIErrorCodeTests: XCTestCase {
                        APIErrorCode.transactionInsufficientFunds)
         XCTAssertEqual(APIErrorCode(rawValue: "websocket:connect_error"),
                        APIErrorCode.websocketError)
-        XCTAssertEqual(APIErrorCode(rawValue: "request:expired"),
+        XCTAssertEqual(APIErrorCode(rawValue: "transaction_request:expired"),
                        APIErrorCode.requestExpired)
-        XCTAssertEqual(APIErrorCode(rawValue: "request:max_consumptions_reached"),
+        XCTAssertEqual(APIErrorCode(rawValue: "transaction_request:max_consumptions_reached"),
                        APIErrorCode.maxConsumptionsReached)
+        XCTAssertEqual(APIErrorCode(rawValue: "transaction_request:max_consumptions_per_user_reached"),
+                       APIErrorCode.maxConsumptionsPerUserReached)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_consumption:not_owner"),
                        APIErrorCode.notOwnerOfTransactionConsumption)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_consumption:invalid_minted_token"),

--- a/OmiseGOTests/CodingTests/EncodeTests.swift
+++ b/OmiseGOTests/CodingTests/EncodeTests.swift
@@ -161,6 +161,7 @@ class EncodeTests: XCTestCase {
                                                consumptionLifetime: 1000,
                                                expirationDate: Date(timeIntervalSince1970: 0),
                                                allowAmountOverride: true,
+                                               maxConsumptionsPerUser: 5,
                                                metadata: [:],
                                                encryptedMetadata: [:])!
             let encodedData = try self.encoder.encode(transactionRequestParams)
@@ -179,6 +180,7 @@ class EncodeTests: XCTestCase {
                     "max_consumptions":1,
                     "address":"3b7f1c68-e3bd-4f8f-9916-4af19be95d00",
                     "correlation_id":"31009545-db10-4287-82f4-afb46d9741d8",
+                    "max_consumptions_per_user":5,
                     "expiration_date":"1970-01-01T00:00:00Z"
                 }
             """.uglifiedEncodedString())
@@ -200,6 +202,7 @@ class EncodeTests: XCTestCase {
                                                consumptionLifetime: 1000,
                                                expirationDate: Date(timeIntervalSince1970: 0),
                                                allowAmountOverride: false,
+                                               maxConsumptionsPerUser: 5,
                                                metadata: [:],
                                                encryptedMetadata: [:])!
             let encodedData = try self.encoder.encode(transactionRequestParams)
@@ -216,6 +219,7 @@ class EncodeTests: XCTestCase {
                     "max_consumptions":1,
                     "address":"3b7f1c68-e3bd-4f8f-9916-4af19be95d00",
                     "correlation_id":"31009545-db10-4287-82f4-afb46d9741d8",
+                    "max_consumptions_per_user":5,
                     "expiration_date":"1970-01-01T00:00:00Z"
                 }
             """.uglifiedEncodedString())
@@ -260,6 +264,7 @@ class EncodeTests: XCTestCase {
                                                         createdAt: nil,
                                                         expiredAt: nil,
                                                         allowAmountOverride: true,
+                                                        maxConsumptionsPerUser: nil,
                                                         metadata: [:],
                                                         encryptedMetadata: [:])
             let transactionConsumptionParams = TransactionConsumptionParams(transactionRequest: transactionRequest,

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.approve_transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.approve_transaction_consumption.json
@@ -103,6 +103,7 @@
       "expiration_reason": null,
       "expired_at": null,
       "allow_amount_override": true,
+      "max_consumptions_per_user": null,
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.consume_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.consume_transaction_request.json
@@ -103,6 +103,7 @@
       "expiration_reason": null,
       "expired_at": null,
       "allow_amount_override": true,
+      "max_consumptions_per_user": null,
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.create_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.create_transaction_request.json
@@ -41,6 +41,7 @@
     "expiration_reason": "Expired",
     "expired_at": "2019-01-01T00:00:00Z",
     "allow_amount_override": true,
+    "max_consumptions_per_user": null,
     "metadata": {},
     "encrypted_metadata": {}
   }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.get_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.get_transaction_request.json
@@ -41,6 +41,7 @@
     "expiration_reason": "Expired",
     "expired_at": "2019-01-01T00:00:00Z",
     "allow_amount_override": true,
+    "max_consumptions_per_user": null,
     "metadata": {},
     "encrypted_metadata": {}
   }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.reject_transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.reject_transaction_consumption.json
@@ -103,6 +103,7 @@
       "expiration_reason": null,
       "expired_at": null,
       "allow_amount_override": true,
+      "max_consumptions_per_user": null,
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/socket_response.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/socket_response.json
@@ -107,6 +107,7 @@
       "expiration_reason": null,
       "expired_at": null,
       "allow_amount_override": true,
+      "max_consumptions_per_user": null,
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_consumption.json
@@ -100,6 +100,7 @@
     "expiration_reason": null,
     "expired_at": null,
     "allow_amount_override": true,
+    "max_consumptions_per_user": null,
     "metadata": {},
     "encrypted_metadata": {}
   },

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_request.json
@@ -38,6 +38,7 @@
   "expiration_reason": "Expired",
   "expired_at": "2019-01-01T00:00:00Z",
   "allow_amount_override": true,
+  "max_consumptions_per_user": null,
   "metadata": {},
   "encrypted_metadata": {}
 }

--- a/OmiseGOTests/Helpers/StubGenerator.swift
+++ b/OmiseGOTests/Helpers/StubGenerator.swift
@@ -151,6 +151,7 @@ class StubGenerator {
         createdAt: Date? = nil,
         expiredAt: Date? = nil,
         allowAmountOverride: Bool? = nil,
+        maxConsumptionsPerUser: Int? = nil,
         metadata: [String: Any]? = nil,
         encryptedMetadata: [String: Any]? = nil)
         -> TransactionRequest {
@@ -174,6 +175,7 @@ class StubGenerator {
                 createdAt: createdAt ?? v.createdAt,
                 expiredAt: expiredAt ?? v.expiredAt,
                 allowAmountOverride: allowAmountOverride ?? v.allowAmountOverride,
+                maxConsumptionsPerUser: maxConsumptionsPerUser ?? v.maxConsumptionsPerUser,
                 metadata: metadata ?? v.metadata,
                 encryptedMetadata: encryptedMetadata ?? v.encryptedMetadata
             )
@@ -243,7 +245,9 @@ class StubGenerator {
         consumptionLifetime: Int? = 1000,
         expirationDate: Date? = Date(timeIntervalSince1970: 0),
         allowAmountOverride: Bool = true,
-        metadata: [String: Any] = [:])
+        maxConsumptionsPerUser: Int? = nil,
+        metadata: [String: Any] = [:],
+        encryptedMetadata: [String: Any] = [:])
         -> TransactionRequestCreateParams {
             return TransactionRequestCreateParams(
                 type: type,
@@ -256,7 +260,9 @@ class StubGenerator {
                 consumptionLifetime: consumptionLifetime,
                 expirationDate: expirationDate,
                 allowAmountOverride: allowAmountOverride,
-                metadata: metadata
+                maxConsumptionsPerUser: maxConsumptionsPerUser,
+                metadata: metadata,
+                encryptedMetadata: encryptedMetadata
                 )!
     }
 

--- a/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
+++ b/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
@@ -137,6 +137,7 @@ extension TransactionRequestLiveTests {
             consumptionLifetime: nil,
             expirationDate: Date().addingTimeInterval(60),
             allowAmountOverride: true,
+            maxConsumptionsPerUser: 5,
             metadata: ["a_key": "a_value"])!
         var transactionRequestResult: TransactionRequest?
         let generateRequest = TransactionRequest.generateTransactionRequest(
@@ -149,6 +150,7 @@ extension TransactionRequestLiveTests {
                     XCTAssertEqual(transactionRequest.mintedToken.id, self.validMintedTokenId)
                     XCTAssertEqual(transactionRequest.amount, 1)
                     XCTAssertEqual(transactionRequest.correlationId, creationCorrelationId)
+                    XCTAssertEqual(transactionRequest.maxConsumptionsPerUser, 5)
                 case .fail(error: let error):
                     XCTFail("\(error)")
                 }

--- a/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
+++ b/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
@@ -42,6 +42,7 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                     createdAt: nil,
                                                     expiredAt: nil,
                                                     allowAmountOverride: true,
+                                                    maxConsumptionsPerUser: nil,
                                                     metadata: [:],
                                                     encryptedMetadata: [:])
         XCTAssertNil(TransactionConsumptionParams(transactionRequest: transactionRequest,
@@ -72,6 +73,7 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                     createdAt: nil,
                                                     expiredAt: nil,
                                                     allowAmountOverride: true,
+                                                    maxConsumptionsPerUser: nil,
                                                     metadata: [:],
                                                     encryptedMetadata: [:])
         let params = TransactionConsumptionParams(transactionRequest: transactionRequest,

--- a/OmiseGOTests/ModelTests/TransactionRequestParamsTest.swift
+++ b/OmiseGOTests/ModelTests/TransactionRequestParamsTest.swift
@@ -23,6 +23,7 @@ class TransactionRequestParamsTest: XCTestCase {
                                            consumptionLifetime: 1000,
                                            expirationDate: Date(timeIntervalSince1970: 0),
                                            allowAmountOverride: false,
+                                           maxConsumptionsPerUser: nil,
                                            metadata: [:])
         XCTAssertNotNil(transactionRequestParams)
     }
@@ -39,6 +40,7 @@ class TransactionRequestParamsTest: XCTestCase {
                                            consumptionLifetime: 1000,
                                            expirationDate: Date(timeIntervalSince1970: 0),
                                            allowAmountOverride: true,
+                                           maxConsumptionsPerUser: nil,
                                            metadata: [:])
         XCTAssertNotNil(transactionRequestParams)
     }
@@ -55,6 +57,7 @@ class TransactionRequestParamsTest: XCTestCase {
                                            consumptionLifetime: 1000,
                                            expirationDate: Date(timeIntervalSince1970: 0),
                                            allowAmountOverride: false,
+                                           maxConsumptionsPerUser: nil,
                                            metadata: [:])
         XCTAssertNil(transactionRequestParams)
     }

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ let params = TransactionRequestCreateParams(type: .receive,
                                             consumptionLifetime: 60000,
                                             expirationDate: nil,
                                             allowAmountOverride: true,
+                                            maxConsumptionsPerUser: 5,
                                             metadata: [:],
                                             encryptedMetadata: [:])!
 TransactionRequest.generateTransactionRequest(using: client, params: params) { (transactionRequestResult) in
@@ -320,6 +321,7 @@ Where:
   - `allowAmountOverride`: (optional) Allow or not the consumer to override the amount specified in the request. This needs to be true if the amount is not specified
   > Note that if `amount` is nil and `allowAmountOverride` is false the init will fail and return `nil`.
 
+  - `maxConsumptionsPerUser`: The maximum number of consumptions allowed per unique user
   - `metadata`: Additional metadata embedded with the request
   - `encryptedMetadata`: Additional encrypted metadata embedded with the request
 

--- a/Source/API/APIError.swift
+++ b/Source/API/APIError.swift
@@ -79,6 +79,7 @@ public enum APIErrorCode: Decodable {
     case websocketError
     case requestExpired
     case maxConsumptionsReached
+    case maxConsumptionsPerUserReached
     case notOwnerOfTransactionConsumption
     case invalidMintedTokenForTransactionConsumption
     case transactionConsumptionExpired
@@ -127,10 +128,12 @@ extension APIErrorCode: RawRepresentable {
             self = .transactionInsufficientFunds
         case "websocket:connect_error":
             self = .websocketError
-        case "request:expired":
+        case "transaction_request:expired":
             self = .requestExpired
-        case "request:max_consumptions_reached":
+        case "transaction_request:max_consumptions_reached":
             self = .maxConsumptionsReached
+        case "transaction_request:max_consumptions_per_user_reached":
+            self = .maxConsumptionsPerUserReached
         case "transaction_consumption:not_owner":
             self = .notOwnerOfTransactionConsumption
         case "transaction_consumption:invalid_minted_token":
@@ -177,9 +180,11 @@ extension APIErrorCode: RawRepresentable {
         case .websocketError:
             return "websocket:connect_error"
         case .requestExpired:
-            return "request:expired"
+            return "transaction_request:expired"
         case .maxConsumptionsReached:
-            return "request:max_consumptions_reached"
+            return "transaction_request:max_consumptions_reached"
+        case .maxConsumptionsPerUserReached:
+            return "transaction_request:max_consumptions_per_user_reached"
         case .notOwnerOfTransactionConsumption:
             return "transaction_consumption:not_owner"
         case .invalidMintedTokenForTransactionConsumption:

--- a/Source/Models/TransactionRequest.swift
+++ b/Source/Models/TransactionRequest.swift
@@ -66,6 +66,8 @@ public struct TransactionRequest {
     public let expiredAt: Date?
     /// Allow or not the consumer to override the amount specified in the request
     public let allowAmountOverride: Bool
+    /// The maximum number of consumptions allowed per unique user
+    public let maxConsumptionsPerUser: Int?
     /// Additional metadata for the request
     public let metadata: [String: Any]
     /// Additional encrypted metadata for the request
@@ -96,6 +98,7 @@ extension TransactionRequest: Decodable {
         case createdAt = "created_at"
         case expiredAt = "expired_at"
         case allowAmountOverride = "allow_amount_override"
+        case maxConsumptionsPerUser = "max_consumptions_per_user"
         case metadata
         case encryptedMetadata = "encrypted_metadata"
     }
@@ -120,6 +123,7 @@ extension TransactionRequest: Decodable {
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         expiredAt = try container.decodeIfPresent(Date.self, forKey: .expiredAt)
         allowAmountOverride = try container.decode(Bool.self, forKey: .allowAmountOverride)
+        maxConsumptionsPerUser = try container.decodeIfPresent(Int.self, forKey: .maxConsumptionsPerUser)
         metadata = try container.decode([String: Any].self, forKey: .metadata)
         encryptedMetadata = try container.decode([String: Any].self, forKey: .encryptedMetadata)
     }

--- a/Source/Models/TransactionRequestParams.swift
+++ b/Source/Models/TransactionRequestParams.swift
@@ -34,6 +34,8 @@ public struct TransactionRequestCreateParams {
     /// Allow or not the consumer to override the amount specified in the request
     /// This needs to be true if the amount is not specified
     public let allowAmountOverride: Bool
+    /// The maximum number of consumptions allowed per unique user
+    public let maxConsumptionsPerUser: Int?
     /// Additional metadata embedded with the request
     public let metadata: [String: Any]
     /// Additional encrypted metadata embedded with the request
@@ -58,7 +60,9 @@ public struct TransactionRequestCreateParams {
     ///   - expirationDate: The date when the request will expire and not be consumable anymore
     ///   - allowAmountOverride: Allow or not the consumer to override the amount specified in the request
     ///                          This needs to be true if the amount is not specified
+    ///   - maxConsumptionsPerUser: The maximum number of consumptions allowed per unique user
     ///   - metadata: Additional metadata embeded with the request
+    ///   - encryptedMetadata: Additional encrypted metadata embedded with the request
     public init?(type: TransactionRequestType,
                  mintedTokenId: String,
                  amount: Double?,
@@ -69,6 +73,7 @@ public struct TransactionRequestCreateParams {
                  consumptionLifetime: Int?,
                  expirationDate: Date?,
                  allowAmountOverride: Bool,
+                 maxConsumptionsPerUser: Int?,
                  metadata: [String: Any] = [:],
                  encryptedMetadata: [String: Any] = [:]) {
         guard allowAmountOverride || amount != nil else { return nil }
@@ -82,6 +87,7 @@ public struct TransactionRequestCreateParams {
         self.consumptionLifetime = consumptionLifetime
         self.expirationDate = expirationDate
         self.allowAmountOverride = allowAmountOverride
+        self.maxConsumptionsPerUser = maxConsumptionsPerUser
         self.metadata = metadata
         self.encryptedMetadata = encryptedMetadata
     }
@@ -101,6 +107,7 @@ extension TransactionRequestCreateParams: APIParameters {
         case consumptionLifetime = "consumption_lifetime"
         case expirationDate = "expiration_date"
         case allowAmountOverride = "allow_amount_override"
+        case maxConsumptionsPerUser = "max_consumptions_per_user"
         case metadata
         case encryptedMetadata = "encrypted_metadata"
     }
@@ -118,6 +125,7 @@ extension TransactionRequestCreateParams: APIParameters {
         try container.encode(consumptionLifetime, forKey: .consumptionLifetime)
         try container.encode(expirationDate, forKey: .expirationDate)
         try container.encode(allowAmountOverride, forKey: .allowAmountOverride)
+        try container.encode(maxConsumptionsPerUser, forKey: .maxConsumptionsPerUser)
         try container.encode(metadata, forKey: .metadata)
         try container.encode(encryptedMetadata, forKey: .encryptedMetadata)
     }


### PR DESCRIPTION
Issue/Task Number: 281

# Overview

This PR add the `maxConsumptionPerUser` attribute on `TransactionRequest`

# Changes

- Add `maxConsumptionPerUser` on `TransactionRequest` and `TransactionRequestParams`

# Implementation Details

This PR follows the API update from [this PR](https://github.com/omisego/ewallet/pull/185)
