### PR TITLE
Rename TransactionRequest methods for more consistency

### DIFF
--- a/OmiseGOTests/FixtureTests/TransactionRequestFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionRequestFixtureTests.swift
@@ -21,7 +21,7 @@ class TransactionRequestFixtureTests: FixtureTestCase {
                 address: "3b7f1c68-e3bd-4f8f-9916-4af19be95d00",
                 correlationId: "31009545-db10-4287-82f4-afb46d9741d8")
         let request =
-            TransactionRequest.generateTransactionRequest(using: self.testCustomClient, params: params) { (result) in
+            TransactionRequest.create(using: self.testCustomClient, params: params) { (result) in
                 defer { expectation.fulfill() }
                 switch result {
                 case .success(data: let transactionRequest):
@@ -54,7 +54,7 @@ class TransactionRequestFixtureTests: FixtureTestCase {
         let expectation =
             self.expectation(description: "Retrieve a transaction request corresponding to the params provided")
         let request =
-            TransactionRequest.retrieveTransactionRequest(
+            TransactionRequest.get(
                 using: self.testCustomClient,
                 id: "8eb0160e-1c96-481a-88e1-899399cc84dc") { (result) in
                     defer { expectation.fulfill() }

--- a/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
+++ b/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
@@ -140,7 +140,7 @@ extension TransactionRequestLiveTests {
             maxConsumptionsPerUser: 5,
             metadata: ["a_key": "a_value"])!
         var transactionRequestResult: TransactionRequest?
-        let generateRequest = TransactionRequest.generateTransactionRequest(
+        let generateRequest = TransactionRequest.create(
             using: self.testClient,
             params: transactionRequestParams) { (result) in
                 defer { generateExpectation.fulfill() }
@@ -163,7 +163,7 @@ extension TransactionRequestLiveTests {
     func getTransactionRequest(transactionRequestId: String, creationCorrelationId: String) {
         var transactionRequestResult: TransactionRequest?
         let getExpectation = self.expectation(description: "Get transaction request")
-        let getRequest = TransactionRequest.retrieveTransactionRequest(
+        let getRequest = TransactionRequest.get(
             using: self.testClient,
             id: transactionRequestId) { (result) in
                 defer { getExpectation.fulfill() }

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ let params = TransactionRequestCreateParams(type: .receive,
                                             maxConsumptionsPerUser: 5,
                                             metadata: [:],
                                             encryptedMetadata: [:])!
-TransactionRequest.generateTransactionRequest(using: client, params: params) { (transactionRequestResult) in
+TransactionRequest.create(using: client, params: params) { (transactionRequestResult) in
     switch transactionRequestResult {
     case .success(data: let transactionRequest):
         //TODO: Do something with the transaction request (get the QR code representation for example)

--- a/Source/Models/TransactionRequest.swift
+++ b/Source/Models/TransactionRequest.swift
@@ -154,9 +154,9 @@ extension TransactionRequest: Retrievable {
     ///   - params: The TransactionRequestCreateParams object describing the transaction request to be made.
     ///   - callback: The closure called when the request is completed
     /// - Returns: An optional cancellable request.
-    public static func generateTransactionRequest(using client: HTTPClient,
-                                                  params: TransactionRequestCreateParams,
-                                                  callback: @escaping TransactionRequest.RetrieveRequestCallback)
+    public static func create(using client: HTTPClient,
+                              params: TransactionRequestCreateParams,
+                              callback: @escaping TransactionRequest.RetrieveRequestCallback)
         -> TransactionRequest.RetrieveRequest? {
             return self.retrieve(using: client,
                                  endpoint: .transactionRequestCreate(params: params),
@@ -172,9 +172,9 @@ extension TransactionRequest: Retrievable {
     ///   - id: The id of the TransactionRequest to be retrived.
     ///   - callback: The closure called when the request is completed
     /// - Returns: An optional cancellable request.
-    public static func retrieveTransactionRequest(using client: HTTPClient,
-                                                  id: String,
-                                                  callback: @escaping TransactionRequest.RetrieveRequestCallback)
+    public static func get(using client: HTTPClient,
+                           id: String,
+                           callback: @escaping TransactionRequest.RetrieveRequestCallback)
         -> TransactionRequest.RetrieveRequest? {
             let params = TransactionRequestGetParams(id: id)
             return self.retrieve(using: client,

--- a/Source/QRCode/QRScannerViewModel.swift
+++ b/Source/QRCode/QRScannerViewModel.swift
@@ -52,7 +52,7 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
         self.loadedIds.append(id)
         self.stopScanning()
         self.onLoadingStateChange?(true)
-        TransactionRequest.retrieveTransactionRequest(using: self.client, id: id) { (result) in
+        TransactionRequest.get(using: self.client, id: id) { (result) in
             self.onLoadingStateChange?(false)
             switch result {
             case .success(data: let transactionRequest):


### PR DESCRIPTION
Issue/Task Number: 302

# Overview

This PR rename 2 methods of `TransactionRequest` for more consustency.

# Changes

- `TransactionRequest.generateTransactionRequest()` -> `TransactionRequest.create()`
- `TransactionRequest.retrieveTransactionRequest()` -> `TransactionRequest.get()`

# Impact

Apps that use these methods will need to rename them as well.
