### PR TITLE
T307 me.transfer

### DIFF
--- a/OmiseGO.podspec
+++ b/OmiseGO.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OmiseGO'
-  s.version = '0.9.11'
+  s.version = '0.10.0'
   s.license = 'Apache'
   s.summary = 'The OmiseGO iOS SDK allows developers to easily interact with a node of the OmiseGO eWallet.'
   s.homepage = 'https://github.com/omisego/ios-sdk'

--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		0377EBB220564ECF0036A9D6 /* SocketPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377EBB120564ECF0036A9D6 /* SocketPayload.swift */; };
 		037BAA99205F64CC004A3952 /* SocketDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037BAA98205F64CC004A3952 /* SocketDispatcher.swift */; };
 		037BAA9B205F701F004A3952 /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037BAA9A205F701E004A3952 /* RequestBuilder.swift */; };
+		037D6A9F20B2541700F02CC8 /* TransactionParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037D6A9E20B2541700F02CC8 /* TransactionParams.swift */; };
 		038A42561F8DE786001A00E0 /* UserFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038A42551F8DE786001A00E0 /* UserFixtureTests.swift */; };
 		038CB3E5202AE93900E40715 /* QRTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038CB3E4202AE93900E40715 /* QRTestHelper.swift */; };
 		038CB3E7202AF81900E40715 /* TransactionConsumptionParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038CB3E6202AF81900E40715 /* TransactionConsumptionParams.swift */; };
@@ -208,6 +209,7 @@
 		0377EBB120564ECF0036A9D6 /* SocketPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketPayload.swift; sourceTree = "<group>"; };
 		037BAA98205F64CC004A3952 /* SocketDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketDispatcher.swift; sourceTree = "<group>"; };
 		037BAA9A205F701E004A3952 /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestBuilder.swift; sourceTree = "<group>"; };
+		037D6A9E20B2541700F02CC8 /* TransactionParams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionParams.swift; sourceTree = "<group>"; };
 		038A42551F8DE786001A00E0 /* UserFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFixtureTests.swift; sourceTree = "<group>"; };
 		038CB3E4202AE93900E40715 /* QRTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRTestHelper.swift; sourceTree = "<group>"; };
 		038CB3E6202AF81900E40715 /* TransactionConsumptionParams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionConsumptionParams.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				0355969A2045315F000E38DA /* TransactionExchange.swift */,
 				039DA974203FA94100CCC56A /* PaginationParams.swift */,
 				039DA976203FAB0600CCC56A /* TransactionListParams.swift */,
+				037D6A9E20B2541700F02CC8 /* TransactionParams.swift */,
 				039DA972203FA72800CCC56A /* Transaction.swift */,
 				039DA978203FB53F00CCC56A /* Pagination.swift */,
 				0361289F20872E7D00E13514 /* Account.swift */,
@@ -782,6 +785,7 @@
 				039DA979203FB53F00CCC56A /* Pagination.swift in Sources */,
 				0365DE8520285FE700F7B42E /* TransactionRequest.swift in Sources */,
 				037032B81FBBE6B100DBCDDD /* Request.swift in Sources */,
+				037D6A9F20B2541700F02CC8 /* TransactionParams.swift in Sources */,
 				037032A91FBBE6B100DBCDDD /* Wallet.swift in Sources */,
 				037032AA1FBBE6B100DBCDDD /* User.swift in Sources */,
 				0355969920453069000E38DA /* TransactionSource.swift in Sources */,

--- a/OmiseGOTests/APITests/APIErrorTests.swift
+++ b/OmiseGOTests/APITests/APIErrorTests.swift
@@ -43,28 +43,35 @@ class APIErrorCodeTests: XCTestCase {
                        APIErrorCode.endPointNotFound)
         XCTAssertEqual(APIErrorCode(rawValue: "client:invalid_api_key"),
                        APIErrorCode.invalidAPIKey)
+        XCTAssertEqual(APIErrorCode(rawValue: "client:no_idempotency_token_provided"),
+                       APIErrorCode.missingIdempotencyToken)
+
         XCTAssertEqual(APIErrorCode(rawValue: "server:internal_server_error"),
                        APIErrorCode.internalServerError)
         XCTAssertEqual(APIErrorCode(rawValue: "server:unknown_error"),
                        APIErrorCode.unknownServerError)
+
         XCTAssertEqual(APIErrorCode(rawValue: "user:access_token_not_found"),
                        APIErrorCode.accessTokenNotFound)
         XCTAssertEqual(APIErrorCode(rawValue: "user:access_token_expired"),
                        APIErrorCode.accessTokenExpired)
-        XCTAssertEqual(APIErrorCode(rawValue: "client:no_idempotency_token_provided"),
-                       APIErrorCode.missingIdempotencyToken)
+        XCTAssertEqual(APIErrorCode(rawValue: "user:from_address_not_found"),
+                       APIErrorCode.fromAddressNotFound)
+        XCTAssertEqual(APIErrorCode(rawValue: "user:from_address_mismatch"),
+                       APIErrorCode.fromAddressMismatch)
+
         XCTAssertEqual(APIErrorCode(rawValue: "transaction:same_address"),
                        APIErrorCode.transactionSameAddress)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction:insufficient_funds"),
                        APIErrorCode.transactionInsufficientFunds)
-        XCTAssertEqual(APIErrorCode(rawValue: "websocket:connect_error"),
-                       APIErrorCode.websocketError)
+
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_request:expired"),
                        APIErrorCode.requestExpired)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_request:max_consumptions_reached"),
                        APIErrorCode.maxConsumptionsReached)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_request:max_consumptions_per_user_reached"),
                        APIErrorCode.maxConsumptionsPerUserReached)
+
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_consumption:not_owner"),
                        APIErrorCode.notOwnerOfTransactionConsumption)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_consumption:invalid_minted_token"),
@@ -73,10 +80,13 @@ class APIErrorCodeTests: XCTestCase {
                        APIErrorCode.transactionConsumptionExpired)
         XCTAssertEqual(APIErrorCode(rawValue: "transaction_consumption:unfinalized"),
                        APIErrorCode.transactionConsumptionUnfinalized)
+
         XCTAssertEqual(APIErrorCode(rawValue: "websocket:forbidden_channel"),
                        APIErrorCode.forbiddenChannel)
         XCTAssertEqual(APIErrorCode(rawValue: "websocket:channel_not_found"),
                        APIErrorCode.channelNotFound)
+        XCTAssertEqual(APIErrorCode(rawValue: "websocket:connect_error"),
+                       APIErrorCode.websocketError)
         XCTAssertEqual(APIErrorCode(rawValue: "an other code"),
                        APIErrorCode.other("an other code"))
     }

--- a/OmiseGOTests/CodingTests/EncodeTests.swift
+++ b/OmiseGOTests/CodingTests/EncodeTests.swift
@@ -427,4 +427,29 @@ class EncodeTests: XCTestCase {
         }
     }
 
+    func testTransactionParamsEncoding() {
+        do {
+            let transactionParams = TransactionSendParams(from: "86e274e2-c8dc-46cf-ac4e-d8b26b5aada3",
+                                                          to: "2bd75f2f-6e83-4727-a8b5-2849a9715064",
+                                                          amount: 1337,
+                                                          mintedTokenId: "BTC:06b8ebc3-237b-4631-a1c7-2ecbd1d623c6",
+                                                          metadata: ["a_key": "a_value"],
+                                                          encryptedMetadata: ["a_key": "a_value"])
+            let encodedData = try self.encoder.encode(transactionParams)
+            let encodedPayload = try! transactionParams.encodedPayload()
+            XCTAssertEqual(encodedData, encodedPayload)
+            XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
+                {
+                    "amount":1337,
+                    "metadata":{"a_key":"a_value"},
+                    "from_address":"86e274e2-c8dc-46cf-ac4e-d8b26b5aada3",
+                    "token_id":"BTC:06b8ebc3-237b-4631-a1c7-2ecbd1d623c6",
+                    "to_address":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
+                    "encrypted_metadata":{"a_key":"a_value"}}
+            """.uglifiedEncodedString())
+        } catch let thrownError {
+            XCTFail(thrownError.localizedDescription)
+        }
+    }
+
 }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.transfer.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.transfer.json
@@ -1,0 +1,48 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "object": "transaction",
+    "id": "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+    "from": {
+      "object": "transaction_source",
+      "address": "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+      "amount": 1000,
+      "minted_token": {
+        "object": "minted_token",
+        "id": "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+        "symbol": "BTC",
+        "name": "Bitcoin",
+        "subunit_to_unit": 100,
+        "metadata": {},
+        "encrypted_metadata": {},
+        "created_at": "2018-01-01T00:00:00Z",
+        "updated_at": "2018-01-01T00:00:00Z"
+      }
+    },
+    "to": {
+      "object": "transaction_source",
+      "address": "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+      "amount": 1000,
+      "minted_token": {
+        "object": "minted_token",
+        "id": "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+        "symbol": "BTC",
+        "name": "Bitcoin",
+        "subunit_to_unit": 100,
+        "metadata": {},
+        "encrypted_metadata": {},
+        "created_at": "2018-01-01T00:00:00Z",
+        "updated_at": "2018-01-01T00:00:00Z"
+      }
+    },
+    "exchange": {
+      "object": "exchange",
+      "rate": 1
+    },
+    "status": "confirmed",
+    "metadata": {},
+    "encrypted_metadata": {},
+    "created_at": "2018-01-01T00:00:00Z"
+  }
+}

--- a/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionFixtureTests.swift
@@ -58,4 +58,42 @@ class TransactionFixtureTests: FixtureTestCase {
         waitForExpectations(timeout: 15.0, handler: nil)
     }
 
+    func testCreateTransaction() {
+        let expectation = self.expectation(description: "Generate a transaction")
+        let params = TransactionSendParams(from: "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+                                           to: "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+                                           amount: 1000,
+                                           mintedTokenId: "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+        let request = Transaction.send(using: self.testCustomClient, params: params) { (result) in
+            defer { expectation.fulfill() }
+            switch result {
+            case .success(data: let transaction):
+                XCTAssertEqual(transaction.id, "ce3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+                let from = transaction.from
+                XCTAssertEqual(from.address, "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+                let fromMintedToken = from.mintedToken
+                XCTAssertEqual(fromMintedToken.id, "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+                XCTAssertEqual(fromMintedToken.symbol, "BTC")
+                XCTAssertEqual(fromMintedToken.name, "Bitcoin")
+                XCTAssertEqual(fromMintedToken.subUnitToUnit, 100)
+                let to = transaction.to
+                XCTAssertEqual(to.address, "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+                let toMintedToken = to.mintedToken
+                XCTAssertEqual(toMintedToken.id, "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+                XCTAssertEqual(toMintedToken.symbol, "BTC")
+                XCTAssertEqual(toMintedToken.name, "Bitcoin")
+                XCTAssertEqual(toMintedToken.subUnitToUnit, 100)
+                let exchange = transaction.exchange
+                XCTAssertEqual(exchange.rate, 1)
+                XCTAssertEqual(transaction.status, .confirmed)
+                XCTAssertTrue(transaction.metadata.isEmpty)
+                XCTAssertTrue(transaction.encryptedMetadata.isEmpty)
+                XCTAssertEqual(transaction.createdAt, "2018-01-01T00:00:00Z".toDate())
+            case .fail(error: let error):
+                XCTFail("\(error)")
+            }
+        }
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The [OmiseGO](https://omisego.network) iOS SDK allows developers to easily inter
       - [Get the provider settings](#get-the-provider-settings)
       - [Get the current user's transactions](#get-the-current-users-transactions)
     - [Transferring tokens](#transferring-tokens)
+      - [Send tokens to an address](#send-tokens-to-an-address)
       - [Generate a transaction request](#generate-a-transaction-request)
       - [Consume a transaction request](#consume-a-transaction-request)
       - [Approve a transaction consumption](#approve-a-transaction-consumption)
@@ -275,10 +276,39 @@ Where:
 
 ### Transferring tokens
 
-In order to transfer tokens between 2 addresses, the SDK offers the possibility to generate and consume transaction requests.
-To make a transaction happen, a `TransactionRequest` needs to be created and consumed by a `TransactionConsumption`.
+The SDK offers 2 ways for transferring tokens between addresses:
+- A simple one way transfer from one of the current user's wallets to an address.
+- A highly configurable send/receive mechanism in 2 steps using transaction requests.
+
+#### Send tokens to an address
+
+The most basic way to transfer tokens is to use the `Transaction.send()` method, which allows the current user to send tokens from one of its wallet to a specific address.
+
+```swift
+let params = TransactionSendParams(from: "1e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+                                   to: "2e3982f5-4a27-498d-a91b-7bb2e2a8d3d1",
+                                   amount: 1000,
+                                   mintedTokenId: "BTC:xe3982f5-4a27-498d-a91b-7bb2e2a8d3d1")
+Transaction.send(using: client, params: params) { (result) in
+   switch result {
+   case .success(data: let transaction):
+       // TODO: Do something with the transaction
+   case .fail(error: let error):
+       XCTFail("\(error)")
+   }
+}
+```
+
+Where:
+- `from`: an optional address that belongs to the user
+- `to`: the destination address
+- `amount`: The amount of token to send
+- `mintedTokenId`: The id of the token to send
 
 #### Generate a transaction request
+
+A more configurable way to transfer tokens between 2 addresses is to use the transaction request flow.
+To make a transaction happen, a `TransactionRequest` needs to be created and consumed by a `TransactionConsumption`.
 
 To generate a transaction request you can call:
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Transaction.send(using: client, params: params) { (result) in
 ```
 
 Where:
-- `from`: an optional address that belongs to the user
+- `from`: an optional address that belongs to the user, use primary wallet address if not specified
 - `to`: the destination address
 - `amount`: The amount of token to send
 - `mintedTokenId`: The id of the token to send

--- a/Source/API/APIEndpoint.swift
+++ b/Source/API/APIEndpoint.swift
@@ -13,6 +13,7 @@ enum APIEndpoint {
     case getWallets
     case getSettings
     case getTransactions(params: TransactionListParams)
+    case createTransaction(params: TransactionSendParams)
     case transactionRequestCreate(params: TransactionRequestCreateParams)
     case transactionRequestGet(params: TransactionRequestGetParams)
     case transactionRequestConsume(params: TransactionConsumptionParams)
@@ -31,6 +32,8 @@ enum APIEndpoint {
             return "/me.get_settings"
         case .getTransactions:
             return "/me.list_transactions"
+        case .createTransaction:
+            return "/me.transfer"
         case .transactionRequestCreate:
             return "/me.create_transaction_request"
         case .transactionRequestGet:
@@ -52,6 +55,8 @@ enum APIEndpoint {
         switch self {
         case .getCurrentUser, .getWallets, .getSettings, .logout: // Send no parameters
             return .requestPlain
+        case .createTransaction(let parameters):
+            return .requestParameters(parameters: parameters)
         case .transactionRequestCreate(let parameters):
             return .requestParameters(parameters: parameters)
         case .transactionRequestGet(let parameters):

--- a/Source/API/APIError.swift
+++ b/Source/API/APIError.swift
@@ -64,28 +64,37 @@ extension APIError: Equatable {
 // Represents the different API error codes
 public enum APIErrorCode: Decodable {
 
+    // Client
     case invalidParameters
     case invalidVersion
     case permissionError
     case endPointNotFound
     case invalidAPIKey
+    case missingIdempotencyToken
+    // Server
     case internalServerError
     case unknownServerError
+    // User
     case accessTokenNotFound
     case accessTokenExpired
-    case missingIdempotencyToken
+    case fromAddressNotFound
+    case fromAddressMismatch
+    // Transaction
     case transactionSameAddress
     case transactionInsufficientFunds
-    case websocketError
+    // Transaction request
     case requestExpired
     case maxConsumptionsReached
     case maxConsumptionsPerUserReached
+    // Transaction consumption
     case notOwnerOfTransactionConsumption
     case invalidMintedTokenForTransactionConsumption
     case transactionConsumptionExpired
     case transactionConsumptionUnfinalized
+    // Websocket
     case forbiddenChannel
     case channelNotFound
+    case websocketError
     case other(String)
 
     public init(from decoder: Decoder) throws {
@@ -112,6 +121,8 @@ extension APIErrorCode: RawRepresentable {
             self = .endPointNotFound
         case "client:invalid_api_key":
             self = .invalidAPIKey
+        case "client:no_idempotency_token_provided":
+            self = .missingIdempotencyToken
         case "server:internal_server_error":
             self = .internalServerError
         case "server:unknown_error":
@@ -120,14 +131,14 @@ extension APIErrorCode: RawRepresentable {
             self = .accessTokenNotFound
         case "user:access_token_expired":
             self = .accessTokenExpired
-        case "client:no_idempotency_token_provided":
-            self = .missingIdempotencyToken
+        case "user:from_address_not_found":
+            self = .fromAddressNotFound
+        case "user:from_address_mismatch":
+            self = .fromAddressMismatch
         case "transaction:same_address":
             self = .transactionSameAddress
         case "transaction:insufficient_funds":
             self = .transactionInsufficientFunds
-        case "websocket:connect_error":
-            self = .websocketError
         case "transaction_request:expired":
             self = .requestExpired
         case "transaction_request:max_consumptions_reached":
@@ -146,6 +157,8 @@ extension APIErrorCode: RawRepresentable {
             self = .forbiddenChannel
         case "websocket:channel_not_found":
             self = .channelNotFound
+        case "websocket:connect_error":
+            self = .websocketError
         case let code:
             self = .other(code)
         }
@@ -163,6 +176,8 @@ extension APIErrorCode: RawRepresentable {
             return "client:endpoint_not_found"
         case .invalidAPIKey:
             return "client:invalid_api_key"
+        case .missingIdempotencyToken:
+            return "client:no_idempotency_token_provided"
         case .internalServerError:
             return "server:internal_server_error"
         case .unknownServerError:
@@ -171,14 +186,14 @@ extension APIErrorCode: RawRepresentable {
             return "user:access_token_not_found"
         case .accessTokenExpired:
             return "user:access_token_expired"
-        case .missingIdempotencyToken:
-            return "client:no_idempotency_token_provided"
+        case .fromAddressNotFound:
+            return "user:from_address_not_found"
+        case .fromAddressMismatch:
+            return "user:from_address_mismatch"
         case .transactionSameAddress:
             return "transaction:same_address"
         case .transactionInsufficientFunds:
             return "transaction:insufficient_funds"
-        case .websocketError:
-            return "websocket:connect_error"
         case .requestExpired:
             return "transaction_request:expired"
         case .maxConsumptionsReached:
@@ -197,6 +212,8 @@ extension APIErrorCode: RawRepresentable {
             return "websocket:forbidden_channel"
         case .channelNotFound:
             return "websocket:channel_not_found"
+        case .websocketError:
+            return "websocket:connect_error"
         case .other(let code):
             return code
         }

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.11</string>
+	<string>0.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/Models/Transaction.swift
+++ b/Source/Models/Transaction.swift
@@ -66,6 +66,25 @@ extension Transaction: Decodable {
 
 }
 
+extension Transaction: Retrievable {
+
+    @discardableResult
+    /// Send tokens to an address
+    ///
+    /// - Parameters:
+    ///   - client: An API client.
+    ///             This client need to be initialized with a ClientConfiguration struct before being used.
+    ///   - params: The TransactionSendParams object to customize the transaction
+    ///   - callback: The closure called when the request is completed
+    /// - Returns: An optional cancellable request.
+    public static func send(using client: HTTPClient,
+                            params: TransactionSendParams,
+                            callback: @escaping Transaction.RetrieveRequestCallback) -> Transaction.RetrieveRequest? {
+        return self.retrieve(using: client, endpoint: .createTransaction(params: params), callback: callback)
+    }
+
+}
+
 extension Transaction: PaginatedListable {
 
     @discardableResult

--- a/Source/Models/TransactionParams.swift
+++ b/Source/Models/TransactionParams.swift
@@ -1,0 +1,63 @@
+//
+//  TransactionParams.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 21/5/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+/// Represents a structure used to create a transaction
+public struct TransactionSendParams {
+
+    /// The address from which to take the tokens (which must belong to the user).
+    /// If not specified, the user's primary balance will be used.
+    public let from: String?
+    /// The address where to send the tokens
+    public let to: String
+    /// The amount of minted token to transfer (down to subunit to unit)
+    public let amount: Double
+    /// The id of the minted token to send
+    public let mintedTokenId: String
+    /// Additional metadata for the transaction
+    public let metadata: [String: Any]
+    /// Additional encrypted metadata for the transaction
+    public let encryptedMetadata: [String: Any]
+
+    public init(from: String? = nil,
+                to: String,
+                amount: Double,
+                mintedTokenId: String,
+                metadata: [String: Any] = [:],
+                encryptedMetadata: [String: Any] = [:]) {
+        self.from = from
+        self.to = to
+        self.amount = amount
+        self.mintedTokenId = mintedTokenId
+        self.metadata = metadata
+        self.encryptedMetadata = encryptedMetadata
+    }
+
+}
+
+extension TransactionSendParams: APIParameters {
+
+    private enum CodingKeys: String, CodingKey {
+        case from = "from_address"
+        case to = "to_address"
+        case amount
+        case mintedTokenId = "token_id"
+        case metadata
+        case encryptedMetadata = "encrypted_metadata"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(from, forKey: .from)
+        try container.encode(to, forKey: .to)
+        try container.encode(amount, forKey: .amount)
+        try container.encode(mintedTokenId, forKey: .mintedTokenId)
+        try container.encode(metadata, forKey: .metadata)
+        try container.encode(encryptedMetadata, forKey: .encryptedMetadata)
+    }
+
+}


### PR DESCRIPTION
Issue/Task Number: 307

# Overview

This PR adds the me.transfer endpoint to allow a user to make a transfer to an other user (address).

# Changes

- Add `Transaction.send()`
- Update Pod version number

#Note:

This PR is comparing with `T291-rename-address-to-wallet` for now, will update after it gets merged.
