### PR TITLE
Add formattedId to transactionRequest and use it for QR representation

### DIFF
--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		037032BC1FBBE7A300DBCDDD /* Tool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037032BB1FBBE7A300DBCDDD /* Tool.swift */; };
 		0370519E2040756F009FD899 /* secret.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0370519D2040756F009FD899 /* secret.plist */; };
 		037051A020407D4A009FD899 /* TransactionRequestLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370519F20407D4A009FD899 /* TransactionRequestLiveTests.swift */; };
+		0370ADC520C634F600942AD5 /* QREncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370ADC420C634F600942AD5 /* QREncodable.swift */; };
 		0371E0BE2062377600A75BCC /* TransactionRequestParamsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0371E0BD2062377600A75BCC /* TransactionRequestParamsTest.swift */; };
 		0377EB70205228730036A9D6 /* SocketDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377EB6F205228730036A9D6 /* SocketDelegate.swift */; };
 		0377EBAE20564E7A0036A9D6 /* SocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0377EBAB20564E7A0036A9D6 /* SocketClient.swift */; };
@@ -201,6 +202,7 @@
 		037032BB1FBBE7A300DBCDDD /* Tool.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tool.swift; sourceTree = "<group>"; };
 		0370519D2040756F009FD899 /* secret.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = secret.plist; sourceTree = "<group>"; };
 		0370519F20407D4A009FD899 /* TransactionRequestLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRequestLiveTests.swift; sourceTree = "<group>"; };
+		0370ADC420C634F600942AD5 /* QREncodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QREncodable.swift; sourceTree = "<group>"; };
 		0371E0BD2062377600A75BCC /* TransactionRequestParamsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRequestParamsTest.swift; sourceTree = "<group>"; };
 		0377EB6F205228730036A9D6 /* SocketDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketDelegate.swift; sourceTree = "<group>"; };
 		0377EBAB20564E7A0036A9D6 /* SocketClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketClient.swift; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 		037032981FBBE6B100DBCDDD /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				0370ADC420C634F600942AD5 /* QREncodable.swift */,
 				037032991FBBE6B100DBCDDD /* Retrievable.swift */,
 				0370329A1FBBE6B100DBCDDD /* Listable.swift */,
 				0365F4F020565011000DA61A /* Listenable.swift */,
@@ -783,6 +786,7 @@
 				03DE596D2089CAEF00E5AE6D /* OMGError.swift in Sources */,
 				0377EBAE20564E7A0036A9D6 /* SocketClient.swift in Sources */,
 				039DA979203FB53F00CCC56A /* Pagination.swift in Sources */,
+				0370ADC520C634F600942AD5 /* QREncodable.swift in Sources */,
 				0365DE8520285FE700F7B42E /* TransactionRequest.swift in Sources */,
 				037032B81FBBE6B100DBCDDD /* Request.swift in Sources */,
 				037D6A9F20B2541700F02CC8 /* TransactionParams.swift in Sources */,

--- a/OmiseGOTests/CodingTests/EncodeTests.swift
+++ b/OmiseGOTests/CodingTests/EncodeTests.swift
@@ -231,13 +231,13 @@ class EncodeTests: XCTestCase {
     func testTransactionRequestGetParamsEncoding() {
         do {
             let transactionRequestParams =
-                TransactionRequestGetParams(id: "0a8a4a98-794b-419e-b92d-514e83657e75")
+                TransactionRequestGetParams(formattedId: "|0a8a4a98-794b-419e-b92d-514e83657e75")
             let encodedData = try self.encoder.encode(transactionRequestParams)
             let encodedPayload = try! transactionRequestParams.encodedPayload()
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData,
                                   encoding: .utf8)!, """
-                {"id":"0a8a4a98-794b-419e-b92d-514e83657e75"}
+                {"formatted_id":"|0a8a4a98-794b-419e-b92d-514e83657e75"}
             """.uglifiedEncodedString())
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
@@ -265,6 +265,7 @@ class EncodeTests: XCTestCase {
                                                         expiredAt: nil,
                                                         allowAmountOverride: true,
                                                         maxConsumptionsPerUser: nil,
+                                                        formattedId: "|0a8a4a98-794b-419e-b92d-514e83657e75",
                                                         metadata: [:],
                                                         encryptedMetadata: [:])
             let transactionConsumptionParams = TransactionConsumptionParams(transactionRequest: transactionRequest,
@@ -282,9 +283,9 @@ class EncodeTests: XCTestCase {
                 {
                     "amount":null,
                     "correlation_id":"321",
+                    "formatted_transaction_request_id":"|0a8a4a98-794b-419e-b92d-514e83657e75",
                     "address":"456",
                     "encrypted_metadata":{},
-                    "transaction_request_id":"0a8a4a98-794b-419e-b92d-514e83657e75",
                     "metadata":{},
                     "token_id":"BTC:123"
                 }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.approve_transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.approve_transaction_consumption.json
@@ -104,6 +104,7 @@
       "expired_at": null,
       "allow_amount_override": true,
       "max_consumptions_per_user": null,
+      "formatted_id": "|907056a4-fc2d-47cb-af19-5e73aade7ece",
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.consume_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.consume_transaction_request.json
@@ -104,6 +104,7 @@
       "expired_at": null,
       "allow_amount_override": true,
       "max_consumptions_per_user": null,
+      "formatted_id": "|907056a4-fc2d-47cb-af19-5e73aade7ece",
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.create_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.create_transaction_request.json
@@ -42,6 +42,7 @@
     "expired_at": "2019-01-01T00:00:00Z",
     "allow_amount_override": true,
     "max_consumptions_per_user": null,
+    "formatted_id": "|8eb0160e-1c96-481a-88e1-899399cc84dc",
     "metadata": {},
     "encrypted_metadata": {}
   }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.get_transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.get_transaction_request.json
@@ -42,6 +42,7 @@
     "expired_at": "2019-01-01T00:00:00Z",
     "allow_amount_override": true,
     "max_consumptions_per_user": null,
+    "formatted_id": "|907056a4-fc2d-47cb-af19-5e73aade7ece",
     "metadata": {},
     "encrypted_metadata": {}
   }

--- a/OmiseGOTests/FixtureTests/Fixtures/fixture/me.reject_transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/fixture/me.reject_transaction_consumption.json
@@ -104,6 +104,7 @@
       "expired_at": null,
       "allow_amount_override": true,
       "max_consumptions_per_user": null,
+      "formatted_id": "|907056a4-fc2d-47cb-af19-5e73aade7ece",
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/socket_response.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/socket_response.json
@@ -108,6 +108,7 @@
       "expired_at": null,
       "allow_amount_override": true,
       "max_consumptions_per_user": null,
+      "formatted_id": "|907056a4-fc2d-47cb-af19-5e73aade7ece",
       "metadata": {},
       "encrypted_metadata": {}
     },

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_consumption.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_consumption.json
@@ -101,6 +101,7 @@
     "expired_at": null,
     "allow_amount_override": true,
     "max_consumptions_per_user": null,
+    "formatted_id": "|907056a4-fc2d-47cb-af19-5e73aade7ece",
     "metadata": {},
     "encrypted_metadata": {}
   },

--- a/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_request.json
+++ b/OmiseGOTests/FixtureTests/Fixtures/objects/transaction_request.json
@@ -39,6 +39,7 @@
   "expired_at": "2019-01-01T00:00:00Z",
   "allow_amount_override": true,
   "max_consumptions_per_user": null,
+  "formatted_id": "|8eb0160e-1c96-481a-88e1-899399cc84dc",
   "metadata": {},
   "encrypted_metadata": {}
 }

--- a/OmiseGOTests/FixtureTests/TransactionRequestFixtureTests.swift
+++ b/OmiseGOTests/FixtureTests/TransactionRequestFixtureTests.swift
@@ -56,7 +56,7 @@ class TransactionRequestFixtureTests: FixtureTestCase {
         let request =
             TransactionRequest.get(
                 using: self.testClient,
-                id: "8eb0160e-1c96-481a-88e1-899399cc84dc") { (result) in
+                formattedId: "|8eb0160e-1c96-481a-88e1-899399cc84dc") { (result) in
                     defer { expectation.fulfill() }
                     switch result {
                     case .success(data: let transactionRequest):

--- a/OmiseGOTests/Helpers/StubGenerator.swift
+++ b/OmiseGOTests/Helpers/StubGenerator.swift
@@ -168,6 +168,7 @@ class StubGenerator {
         expiredAt: Date? = nil,
         allowAmountOverride: Bool? = nil,
         maxConsumptionsPerUser: Int? = nil,
+        formattedId: String? = nil,
         metadata: [String: Any]? = nil,
         encryptedMetadata: [String: Any]? = nil)
         -> TransactionRequest {
@@ -192,6 +193,7 @@ class StubGenerator {
                 expiredAt: expiredAt ?? v.expiredAt,
                 allowAmountOverride: allowAmountOverride ?? v.allowAmountOverride,
                 maxConsumptionsPerUser: maxConsumptionsPerUser ?? v.maxConsumptionsPerUser,
+                formattedId: formattedId ?? v.formattedId,
                 metadata: metadata ?? v.metadata,
                 encryptedMetadata: encryptedMetadata ?? v.encryptedMetadata
             )
@@ -283,9 +285,9 @@ class StubGenerator {
     }
 
     class func transactionRequestGetParams(
-        id: String? = "0a8a4a98-794b-419e-b92d-514e83657e75")
+        formattedId: String? = "|0a8a4a98-794b-419e-b92d-514e83657e75")
         -> TransactionRequestGetParams {
-            return TransactionRequestGetParams(id: id!)
+            return TransactionRequestGetParams(formattedId: formattedId!)
     }
 
     class func transactionConsumptionParams(

--- a/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
+++ b/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
@@ -55,7 +55,7 @@ class TransactionRequestLiveTests: LiveTestCase {
     func testGetATransactionRequest() {
         let creationCorrelationId = UUID().uuidString
         guard let transactionRequest = self.generateTransactionRequest(creationCorrelationId: creationCorrelationId, requiresConfirmation: true) else { return }
-        self.getTransactionRequest(transactionRequestId: transactionRequest.id, creationCorrelationId: creationCorrelationId)
+        self.getTransactionRequest(formattedId: transactionRequest.formattedId, creationCorrelationId: creationCorrelationId)
     }
 
     /// This test asserts that an approved consumption event is immediately sent without the need to approve the consumption
@@ -160,17 +160,17 @@ extension TransactionRequestLiveTests {
         return transactionRequestResult
     }
 
-    func getTransactionRequest(transactionRequestId: String, creationCorrelationId: String) {
+    func getTransactionRequest(formattedId: String, creationCorrelationId: String) {
         var transactionRequestResult: TransactionRequest?
         let getExpectation = self.expectation(description: "Get transaction request")
         let getRequest = TransactionRequest.get(
             using: self.testClient,
-            formattedId: transactionRequestId) { (result) in
+            formattedId: formattedId) { (result) in
                 defer { getExpectation.fulfill() }
                 switch result {
                 case .success(data: let transactionRequest):
                     transactionRequestResult = transactionRequest
-                    XCTAssertEqual(transactionRequest.id, transactionRequestId)
+                    XCTAssertEqual(transactionRequest.formattedId, formattedId)
                     XCTAssertEqual(transactionRequest.token.id, self.validTokenId)
                     XCTAssertEqual(transactionRequest.amount, 1)
                     XCTAssertEqual(transactionRequest.correlationId, creationCorrelationId)

--- a/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
+++ b/OmiseGOTests/LiveTests/TransactionRequestLiveTests.swift
@@ -165,7 +165,7 @@ extension TransactionRequestLiveTests {
         let getExpectation = self.expectation(description: "Get transaction request")
         let getRequest = TransactionRequest.get(
             using: self.testClient,
-            id: transactionRequestId) { (result) in
+            formattedId: transactionRequestId) { (result) in
                 defer { getExpectation.fulfill() }
                 switch result {
                 case .success(data: let transactionRequest):

--- a/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
+++ b/OmiseGOTests/ModelTests/TransactionConsumptionParamsTest.swift
@@ -43,6 +43,7 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                     expiredAt: nil,
                                                     allowAmountOverride: true,
                                                     maxConsumptionsPerUser: nil,
+                                                    formattedId: "|0a8a4a98-794b-419e-b92d-514e83657e75",
                                                     metadata: [:],
                                                     encryptedMetadata: [:])
         XCTAssertNil(TransactionConsumptionParams(transactionRequest: transactionRequest,
@@ -74,6 +75,7 @@ class TransactionConsumptionParamsTest: XCTestCase {
                                                     expiredAt: nil,
                                                     allowAmountOverride: true,
                                                     maxConsumptionsPerUser: nil,
+                                                    formattedId: "|0a8a4a98-794b-419e-b92d-514e83657e75",
                                                     metadata: [:],
                                                     encryptedMetadata: [:])
         let params = TransactionConsumptionParams(transactionRequest: transactionRequest,

--- a/OmiseGOTests/ModelTests/TransactionRequestTest.swift
+++ b/OmiseGOTests/ModelTests/TransactionRequestTest.swift
@@ -15,7 +15,7 @@ class TransactionRequestTest: XCTestCase {
         let transactionRequest = StubGenerator.transactionRequest()
         if let qrImage = transactionRequest.qrImage() {
             let decodedText = QRTestHelper.readQRCode(fromImage: qrImage)
-            XCTAssertEqual(decodedText, transactionRequest.id)
+            XCTAssertEqual(decodedText, transactionRequest.formattedId)
         } else {
             XCTFail("QR image should not be nil")
         }

--- a/OmiseGOTests/QRCodeTests/MockQRReader.swift
+++ b/OmiseGOTests/QRCodeTests/MockQRReader.swift
@@ -53,7 +53,7 @@ class MockQRViewModel: QRScannerViewModelProtocol {
     var didStartScanning: Bool = false
     var didStopScanning: Bool = false
     var didUpdateQRReaderPreviewLayer: Bool = false
-    var didCallLoadTransactionRequestWithId: Bool = false
+    var didCallLoadTransactionRequestWithFormattedId: Bool = false
 
     var onLoadingStateChange: LoadingClosure?
 
@@ -81,7 +81,7 @@ class MockQRViewModel: QRScannerViewModelProtocol {
         return true // for testing purpose we ignore the availabilty of the video device
     }
 
-    func loadTransactionRequest(withId id: String) {
-        self.didCallLoadTransactionRequestWithId = true
+    func loadTransactionRequest(withFormattedId formattedId: String) {
+        self.didCallLoadTransactionRequestWithFormattedId = true
     }
 }

--- a/OmiseGOTests/QRCodeTests/QRScannerViewModelTest.swift
+++ b/OmiseGOTests/QRCodeTests/QRScannerViewModelTest.swift
@@ -18,7 +18,7 @@ class QRScannerViewModelTest: FixtureTestCase {
             defer { exp.fulfill() }
             XCTAssertNotNil(transactionRequest)
         }
-        stub.loadTransactionRequest(withId: "123")
+        stub.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
     }
 
@@ -28,11 +28,11 @@ class QRScannerViewModelTest: FixtureTestCase {
             HTTPClient(config: ClientConfiguration(baseURL: "", apiKey: "", authenticationToken: "")))
         stub.onError = { (error) in
             defer { exp.fulfill() }
-            XCTAssert(stub.loadedIds.contains("123"))
+            XCTAssert(stub.loadedIds.contains("|123"))
             XCTAssertNotNil(error)
-            stub.loadTransactionRequest(withId: "123")
+            stub.loadTransactionRequest(withFormattedId: "|123")
         }
-        stub.loadTransactionRequest(withId: "123")
+        stub.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
     }
 
@@ -49,7 +49,7 @@ class QRScannerViewModelTest: FixtureTestCase {
                 exp.fulfill()
             }
         }
-        stub.loadTransactionRequest(withId: "123")
+        stub.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
     }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - Starscream (~> 3.0)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - Starscream
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b65b55b7361189d8c9b6d31f609db7eba1c61ae8
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/Source/Models/TransactionConsumptionParams.swift
+++ b/Source/Models/TransactionConsumptionParams.swift
@@ -9,8 +9,8 @@
 /// Represents a structure used to consume a transaction request
 public struct TransactionConsumptionParams {
 
-    /// The id of the transaction request to be consumed
-    public let transactionRequestId: String
+    /// The formatted id of the transaction request to be consumed
+    public let formattedTransactionRequestId: String
     /// The amount of token to transfer (down to subunit to unit)
     public let amount: Double?
     /// The address to use for the consumption
@@ -50,7 +50,7 @@ public struct TransactionConsumptionParams {
                  metadata: [String: Any] = [:],
                  encryptedMetadata: [String: Any] = [:]) {
         guard transactionRequest.amount != nil || amount != nil else { return nil }
-        self.transactionRequestId = transactionRequest.id
+        self.formattedTransactionRequestId = transactionRequest.formattedId
         self.amount = amount == transactionRequest.amount ? nil : amount
         self.address = address
         self.tokenId = tokenId
@@ -71,7 +71,7 @@ extension TransactionConsumptionParams: APIParameters {
 extension TransactionConsumptionParams {
 
     private enum CodingKeys: String, CodingKey {
-        case transactionRequestId = "transaction_request_id"
+        case formattedTransactionRequestId = "formatted_transaction_request_id"
         case amount
         case address
         case tokenId = "token_id"
@@ -82,7 +82,7 @@ extension TransactionConsumptionParams {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(transactionRequestId, forKey: .transactionRequestId)
+        try container.encode(formattedTransactionRequestId, forKey: .formattedTransactionRequestId)
         try container.encode(amount, forKey: .amount)
         try container.encode(address, forKey: .address)
         try container.encode(tokenId, forKey: .tokenId)

--- a/Source/Models/TransactionRequestParams.swift
+++ b/Source/Models/TransactionRequestParams.swift
@@ -135,6 +135,10 @@ extension TransactionRequestCreateParams: APIParameters {
 /// Represents a structure used to retrieve a transaction request from its id
 struct TransactionRequestGetParams: APIParameters {
 
-    let id: String
+    let formattedId: String
+
+    private enum CodingKeys: String, CodingKey {
+        case formattedId = "formatted_id"
+    }
 
 }

--- a/Source/Operations/QREncodable.swift
+++ b/Source/Operations/QREncodable.swift
@@ -1,0 +1,25 @@
+//
+//  QREncodable.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 5/6/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+/// A protocol that takes care of the encoding and generating QR images of different structs
+public protocol QREncodable {
+    func qrImage(withSize size: CGSize) -> UIImage?
+}
+
+public extension QREncodable where Self == TransactionRequest {
+
+    /// Generates a QR image containing the encoded transaction request formattedId
+    ///
+    /// - Parameter size: the desired image size
+    /// - Returns: A QR image if the transaction request was successfuly encoded, nil otherwise.
+    public func qrImage(withSize size: CGSize = CGSize(width: 200, height: 200)) -> UIImage? {
+        guard let data = self.formattedId.data(using: .isoLatin1) else { return nil }
+        return QRGenerator.generateQRCode(fromData: data, outputSize: size)
+    }
+
+}

--- a/Source/QRCode/QRScannerViewModel.swift
+++ b/Source/QRCode/QRScannerViewModel.swift
@@ -21,7 +21,7 @@ protocol QRScannerViewModelProtocol {
     func readerPreviewLayer() -> AVCaptureVideoPreviewLayer
     func updateQRReaderPreviewLayer(withFrame frame: CGRect)
     func isQRCodeAvailable() -> Bool
-    func loadTransactionRequest(withId id: String)
+    func loadTransactionRequest(withFormattedId formattedId: String)
 }
 
 class QRScannerViewModel: QRScannerViewModelProtocol {
@@ -34,7 +34,7 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
     private lazy var reader: QRReader = {
         QRReader(onFindClosure: { [weak self] (value) in
             DispatchQueue.main.async {
-                self?.loadTransactionRequest(withId: value)
+                self?.loadTransactionRequest(withFormattedId: value)
             }
         })
     }()
@@ -44,15 +44,15 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
         self.client = client
     }
 
-    func loadTransactionRequest(withId id: String) {
+    func loadTransactionRequest(withFormattedId formattedId: String) {
         // prevent from loading multiple time the same id
-        guard !self.loadedIds.contains(id) else { return }
+        guard !self.loadedIds.contains(formattedId) else { return }
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         generator.impactOccurred()
-        self.loadedIds.append(id)
+        self.loadedIds.append(formattedId)
         self.stopScanning()
         self.onLoadingStateChange?(true)
-        TransactionRequest.get(using: self.client, id: id) { (result) in
+        TransactionRequest.get(using: self.client, formattedId: formattedId) { (result) in
             self.onLoadingStateChange?(false)
             switch result {
             case .success(data: let transactionRequest):


### PR DESCRIPTION
Issue/Task Number: 349

# Overview

This adds the changes from [this PR](https://github.com/omisego/ewallet/pull/221).

# Changes

- Use `formattedId` instead of `id` for transaction request, consumption and qr code encoding.