### PR TITLE
Add client login api

### DIFF
--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -158,6 +158,10 @@
 		03E565B5211AFBB100BC9124 /* QRScannerViewController+Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E565B4211AFBB100BC9124 /* QRScannerViewController+Client.swift */; };
 		03E565B7211AFF9A00BC9124 /* HTTPClient+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E565B6211AFF9A00BC9124 /* HTTPClient+Admin.swift */; };
 		03E565B9211AFFCA00BC9124 /* AdminConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E565B8211AFFCA00BC9124 /* AdminConfiguration.swift */; };
+		03E72EDB2124177E0060E1D7 /* LoginParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDA2124177E0060E1D7 /* LoginParams.swift */; };
+		03E72EDD212424B00060E1D7 /* AuthenticationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */; };
+		03E72EDF2124312C0060E1D7 /* AuthenticationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */; };
+		03F2D500212436BB00BC65BB /* LoginFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */; };
 		0722AF18088B1D5B0C533D3A /* Pods_OmiseGO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F3D88392040FB15FD17E51 /* Pods_OmiseGO.framework */; };
 		9AA7A03093BE5106A618E627 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA7D150759B05A9FDA9B003F /* Pods_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -327,6 +331,10 @@
 		03E565B4211AFBB100BC9124 /* QRScannerViewController+Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "QRScannerViewController+Client.swift"; sourceTree = "<group>"; };
 		03E565B6211AFF9A00BC9124 /* HTTPClient+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPClient+Admin.swift"; sourceTree = "<group>"; };
 		03E565B8211AFFCA00BC9124 /* AdminConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminConfiguration.swift; sourceTree = "<group>"; };
+		03E72EDA2124177E0060E1D7 /* LoginParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginParams.swift; sourceTree = "<group>"; };
+		03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationToken.swift; sourceTree = "<group>"; };
+		03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenTests.swift; sourceTree = "<group>"; };
+		03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFixtureTests.swift; sourceTree = "<group>"; };
 		16499E8AC99F7FCEE0A0FC0E /* Pods-OmiseGO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.release.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.release.xcconfig"; sourceTree = "<group>"; };
 		47235654A4C773217A4C91D9 /* Pods-OmiseGO.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.debug.xcconfig"; sourceTree = "<group>"; };
 		D2F65698E210E4D7AEBCE81C /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -478,6 +486,7 @@
 		032CED6A211D3D5300E44445 /* ModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */,
 				032CED6B211D3D5300E44445 /* TokenTests.swift */,
 				032CED6C211D3D5300E44445 /* TransactionConsumptionParamsTest.swift */,
 				032CED6D211D3D5300E44445 /* TransactionConsumptionTest.swift */,
@@ -555,6 +564,7 @@
 				032CEDC0211D3D5300E44445 /* TransactionFixtureTests.swift */,
 				032CEDC1211D3D5300E44445 /* SettingFixtureTests.swift */,
 				032CEDC2211D3D5300E44445 /* RequestFixtureTest.swift */,
+				03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */,
 			);
 			path = FixtureTests;
 			sourceTree = "<group>";
@@ -626,6 +636,7 @@
 			isa = PBXGroup;
 			children = (
 				0379E7C921184BC800E65D4F /* Account.swift */,
+				03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */,
 				0379E7C121184BC800E65D4F /* Avatar.swift */,
 				0379E7BE21184BC800E65D4F /* Balance.swift */,
 				0379E7C721184BC800E65D4F /* EmptyResponse.swift */,
@@ -647,6 +658,7 @@
 				0379E7BB21184BC800E65D4F /* TransactionRequestParams.swift */,
 				0379E7C521184BC800E65D4F /* TransactionConsumption.swift */,
 				0379E7BD21184BC800E65D4F /* TransactionConsumptionParams.swift */,
+				03E72EDA2124177E0060E1D7 /* LoginParams.swift */,
 				0379E7BC21184BC800E65D4F /* User.swift */,
 				0379E7CB21184BC800E65D4F /* Wallet.swift */,
 			);
@@ -1035,6 +1047,7 @@
 				0379E81521184BC900E65D4F /* Configuration.swift in Sources */,
 				0379E80C21184BC900E65D4F /* QREncodable.swift in Sources */,
 				0379E7FD21184BC900E65D4F /* OMGError.swift in Sources */,
+				03E72EDD212424B00060E1D7 /* AuthenticationToken.swift in Sources */,
 				0320EAC5211966BC0006685C /* AdminCredential.swift in Sources */,
 				0379E80121184BC900E65D4F /* Transaction.swift in Sources */,
 				0379E7F521184BC900E65D4F /* TransactionSource.swift in Sources */,
@@ -1045,6 +1058,7 @@
 				0379E7F021184BC900E65D4F /* SocketClient.swift in Sources */,
 				0379E7F821184BC900E65D4F /* TransactionRequestParams.swift in Sources */,
 				0379E81121184BC900E65D4F /* QRScannerOverlayView.swift in Sources */,
+				03E72EDB2124177E0060E1D7 /* LoginParams.swift in Sources */,
 				03E565B5211AFBB100BC9124 /* QRScannerViewController+Client.swift in Sources */,
 				0379E80521184BC900E65D4F /* TransactionListParams.swift in Sources */,
 				0379E81221184BC900E65D4F /* QRScannerLoadingView.swift in Sources */,
@@ -1075,6 +1089,7 @@
 				032CEDFB211D3D5300E44445 /* DecodingFixtureTests.swift in Sources */,
 				032CEDDA211D3D5300E44445 /* EncodeTests.swift in Sources */,
 				032CEDE6211D3D5300E44445 /* TestQRHelper.swift in Sources */,
+				03E72EDF2124312C0060E1D7 /* AuthenticationTokenTests.swift in Sources */,
 				032CEDD2211D3D5300E44445 /* QRScannerViewModelTests.swift in Sources */,
 				032CEE39211D3D5300E44445 /* TransactionFixtureTests.swift in Sources */,
 				032CEDE4211D3D5300E44445 /* TestConfiguration.swift in Sources */,
@@ -1127,6 +1142,7 @@
 				032CEDD9211D3D5300E44445 /* SocketMessageTests.swift in Sources */,
 				032CEDF1211D3D5300E44445 /* TransactionConsumptionTest.swift in Sources */,
 				032CEDE9211D3D5300E44445 /* TestBigUInt.swift in Sources */,
+				03F2D500212436BB00BC65BB /* LoginFixtureTests.swift in Sources */,
 				032CEDF6211D3D5300E44445 /* UserTests.swift in Sources */,
 				032CEDCF211D3D5300E44445 /* QRGeneratorTests.swift in Sources */,
 				032CEE27211D3D5300E44445 /* APIClientEndpointTest.swift in Sources */,

--- a/Source/Admin/API/AdminCredential.swift
+++ b/Source/Admin/API/AdminCredential.swift
@@ -17,6 +17,10 @@ public struct AdminCredential: Credential {
         return try CredentialEncoder.encode(value1: self.userId, value2: authenticationToken, scheme: "OMGAdmin")
     }
 
+    mutating func update(withAuthenticationToken authenticationToken: AuthenticationToken) {
+        self.authenticationToken = authenticationToken.token
+    }
+
     public mutating func invalidate() {
         self.authenticationToken = nil
     }

--- a/Source/Client/API/APIClientEndpoint.swift
+++ b/Source/Client/API/APIClientEndpoint.swift
@@ -18,8 +18,8 @@ enum APIClientEndpoint: APIEndpoint {
     case transactionRequestConsume(params: TransactionConsumptionParams)
     case transactionConsumptionApprove(params: TransactionConsumptionConfirmationParams)
     case transactionConsumptionReject(params: TransactionConsumptionConfirmationParams)
+    case login(params: LoginParams)
     case logout
-    case custom(path: String, task: HTTPTask)
 
     var path: String {
         switch self {
@@ -43,17 +43,15 @@ enum APIClientEndpoint: APIEndpoint {
             return "/me.approve_transaction_consumption"
         case .transactionConsumptionReject:
             return "/me.reject_transaction_consumption"
+        case .login:
+            return "user.login"
         case .logout:
             return "/me.logout"
-        case .custom(let path, _):
-            return path
         }
     }
 
     var task: HTTPTask {
         switch self {
-        case .getCurrentUser, .getWallets, .getSettings, .logout: // Send no parameters
-            return .requestPlain
         case let .createTransaction(parameters):
             return .requestParameters(parameters: parameters)
         case let .transactionRequestCreate(parameters):
@@ -68,8 +66,9 @@ enum APIClientEndpoint: APIEndpoint {
             return .requestParameters(parameters: parameters)
         case let .transactionConsumptionReject(parameters):
             return .requestParameters(parameters: parameters)
-        case let .custom(_, task):
-            return task
+        case let .login(parameters):
+            return .requestParameters(parameters: parameters)
+        default: return .requestPlain
         }
     }
 }

--- a/Source/Client/API/ClientCredential.swift
+++ b/Source/Client/API/ClientCredential.swift
@@ -16,17 +16,19 @@ public struct ClientCredential: Credential {
     ///
     /// - Parameters:
     ///   - apiKey: The API key to use for the authenticated calls
-    ///   - authenticationToken: The authentication token of the user
-    public init(apiKey: String, authenticationToken: String) {
+    ///   - authenticationToken: The authentication token of the user. Can be nil if doing request that don't need authentication.
+    public init(apiKey: String, authenticationToken: String? = nil) {
         self.apiKey = apiKey
         self.authenticationToken = authenticationToken
     }
 
     func authentication() throws -> String? {
-        guard let authenticationToken = self.authenticationToken else {
-            throw OMGError.configuration(message: "Authentication token is required")
-        }
+        guard let authenticationToken = self.authenticationToken else { return nil }
         return try CredentialEncoder.encode(value1: self.apiKey, value2: authenticationToken, scheme: "OMGClient")
+    }
+
+    mutating func update(withAuthenticationToken authenticationToken: AuthenticationToken) {
+        self.authenticationToken = authenticationToken.token
     }
 
     public mutating func invalidate() {

--- a/Source/Client/API/HTTPClient+Client.swift
+++ b/Source/Client/API/HTTPClient+Client.swift
@@ -46,9 +46,9 @@ extension HTTPClient {
         -> Request<AuthenticationToken>? {
         let request: Request<AuthenticationToken>? = self.request(toEndpoint: APIClientEndpoint.login(params: params)) { result in
             switch result {
-            case let .success(data: data):
-                self.config.credentials.update(withAuthenticationToken: data)
-                callback(.success(data: data))
+            case let .success(data: authenticationToken):
+                self.config.credentials.update(withAuthenticationToken: authenticationToken)
+                callback(.success(data: authenticationToken))
             case let .fail(error):
                 callback(.fail(error: error))
             }

--- a/Source/Client/API/HTTPClient+Client.swift
+++ b/Source/Client/API/HTTPClient+Client.swift
@@ -33,4 +33,26 @@ extension HTTPClient {
         }
         return request
     }
+
+    /// Login a user using an email and a password.
+    /// Once the request is completed successfully, the current client is automatically
+    /// upgraded with the authentication contained in the response.
+    /// It can then be used to make other authenticated calls
+    ///
+    /// - Parameter callback: The closure called when the request is completed
+    /// - Returns: An optional cancellable request.
+    @discardableResult
+    public func loginClient(withParams params: LoginParams, callback: @escaping Request<AuthenticationToken>.Callback)
+        -> Request<AuthenticationToken>? {
+        let request: Request<AuthenticationToken>? = self.request(toEndpoint: APIClientEndpoint.login(params: params)) { result in
+            switch result {
+            case let .success(data: data):
+                self.config.credentials.update(withAuthenticationToken: data)
+                callback(.success(data: data))
+            case let .fail(error):
+                callback(.fail(error: error))
+            }
+        }
+        return request
+    }
 }

--- a/Source/Core/API/Credential.swift
+++ b/Source/Core/API/Credential.swift
@@ -9,5 +9,6 @@
 /// Contains the required functions that a configuration object would need to authenticate an API call if needed
 protocol Credential {
     func authentication() throws -> String?
+    mutating func update(withAuthenticationToken authenticationToken: AuthenticationToken)
     mutating func invalidate()
 }

--- a/Source/Core/Models/AuthenticationToken.swift
+++ b/Source/Core/Models/AuthenticationToken.swift
@@ -10,7 +10,7 @@ public struct AuthenticationToken {
     /// The unique authentication token corresponding to the provided credentials
     public let token: String
     /// The user corresponding to the token
-    public let user: User?
+    public let user: User
 }
 
 extension AuthenticationToken: Decodable {
@@ -22,7 +22,7 @@ extension AuthenticationToken: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         token = try container.decode(String.self, forKey: .token)
-        user = try container.decodeIfPresent(User.self, forKey: .user)
+        user = try container.decode(User.self, forKey: .user)
     }
 }
 

--- a/Source/Core/Models/AuthenticationToken.swift
+++ b/Source/Core/Models/AuthenticationToken.swift
@@ -1,0 +1,37 @@
+//
+//  AuthenticationToken.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 15/8/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+public struct AuthenticationToken {
+    /// The unique authentication token corresponding to the provided credentials
+    public let token: String
+    /// The user corresponding to the token
+    public let user: User?
+}
+
+extension AuthenticationToken: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case token = "authentication_token"
+        case user
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        token = try container.decode(String.self, forKey: .token)
+        user = try container.decodeIfPresent(User.self, forKey: .user)
+    }
+}
+
+extension AuthenticationToken: Hashable {
+    public var hashValue: Int {
+        return self.token.hashValue
+    }
+
+    public static func == (lhs: AuthenticationToken, rhs: AuthenticationToken) -> Bool {
+        return lhs.token == rhs.token
+    }
+}

--- a/Source/Core/Models/LoginParams.swift
+++ b/Source/Core/Models/LoginParams.swift
@@ -1,0 +1,36 @@
+//
+//  LoginParams.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 15/8/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+/// Represents a structure used to login an existing user
+public struct LoginParams {
+    public let email: String
+    public let password: String
+
+    /// Initialize the params used to login a user
+    ///
+    /// - Parameters:
+    ///   - email: The email of the user
+    ///   - password: The password of the user
+    public init(email: String, password: String) {
+        self.email = email
+        self.password = password
+    }
+}
+
+extension LoginParams: APIParameters {
+    private enum CodingKeys: String, CodingKey {
+        case email
+        case password
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(email, forKey: .email)
+        try container.encode(password, forKey: .password)
+    }
+}

--- a/Source/Core/Models/User.swift
+++ b/Source/Core/Models/User.swift
@@ -11,9 +11,9 @@ public struct User: Listenable {
     /// The unique identifier on the wallet server side
     public let id: String
     /// The user identifier on the provider server side
-    public let providerUserId: String
+    public let providerUserId: String?
     /// The user's username, it can be an email or any name describing this user
-    public let username: String
+    public let username: String?
     /// Any additional metadata that need to be stored as a dictionary
     public let metadata: [String: Any]
     /// Any additional encrypted metadata that need to be stored as a dictionary
@@ -41,8 +41,8 @@ extension User: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(String.self, forKey: .id)
-        providerUserId = try container.decode(String.self, forKey: .providerUserId)
-        username = try container.decode(String.self, forKey: .username)
+        providerUserId = try container.decodeIfPresent(String.self, forKey: .providerUserId)
+        username = try container.decodeIfPresent(String.self, forKey: .username)
         metadata = try container.decode([String: Any].self, forKey: .metadata)
         encryptedMetadata = try container.decode([String: Any].self, forKey: .encryptedMetadata)
         createdAt = try container.decode(Date.self, forKey: .createdAt)

--- a/Tests/Client/APITests/ClientCredentialTests.swift
+++ b/Tests/Client/APITests/ClientCredentialTests.swift
@@ -10,9 +10,17 @@
 import XCTest
 
 class ClientCredentialTests: XCTestCase {
-    func testFailToEncodeAuthorizationHeaderIfAuthenticationTokenIsNotSpecified() {
+    func testUpdateCredentialSuccessfully() {
+        var credentials = ClientCredential(apiKey: "api_key")
+        XCTAssertNil(credentials.authenticationToken)
+        let authenticationToken = StubGenerator.authenticationToken(token: "123")
+        credentials.update(withAuthenticationToken: authenticationToken)
+        XCTAssertEqual(credentials.authenticationToken, "123")
+    }
+
+    func testAuthenticationReturnsNilIfAuthenticationTokenIsNotSpecified() {
         var credentials = ClientCredential(apiKey: "api_key", authenticationToken: "auth_token")
         credentials.invalidate()
-        XCTAssertThrowsError(try credentials.authentication())
+        XCTAssertNil(try credentials.authentication())
     }
 }

--- a/Tests/Client/FixtureTests/FixtureClientTestCase.swift
+++ b/Tests/Client/FixtureTests/FixtureClientTestCase.swift
@@ -13,6 +13,8 @@ class FixtureClientTestCase: XCTestCase {
     var testClient: FixtureClient {
         let bundle = Bundle(for: FixtureClientTestCase.self)
         let url = bundle.url(forResource: "client_fixtures", withExtension: nil)!
-        return FixtureClient(fixturesDirectoryURL: url)
+        let credentials = ClientCredential(apiKey: "some_api_key", authenticationToken: "some_token")
+        let config = ClientConfiguration(baseURL: "http://localhost:4000", credentials: credentials)
+        return FixtureClient(fixturesDirectoryURL: url, config: config)
     }
 }

--- a/Tests/Client/FixtureTests/LoginFixtureTests.swift
+++ b/Tests/Client/FixtureTests/LoginFixtureTests.swift
@@ -30,7 +30,7 @@ class LoginFixtureTests: XCTestCase {
                 XCTFail(error.message)
             case let .success(data: authenticationToken):
                 XCTAssertEqual(authenticationToken.token, "azJRj09l7jvR8KhTqUs3")
-                XCTAssertEqual(authenticationToken.user!.id, "usr_01cc02x0v98qcctvycfx4vsk8x")
+                XCTAssertEqual(authenticationToken.user.id, "usr_01cc02x0v98qcctvycfx4vsk8x")
                 XCTAssertNotNil(try! client.config.credentials.authentication())
             }
         })

--- a/Tests/Client/FixtureTests/LoginFixtureTests.swift
+++ b/Tests/Client/FixtureTests/LoginFixtureTests.swift
@@ -1,0 +1,40 @@
+//
+//  LoginFixtureTests.swift
+//  Tests
+//
+//  Created by Mederic Petit on 15/8/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import OmiseGO
+import XCTest
+
+class LoginFixtureTests: XCTestCase {
+    var testClient: FixtureClient {
+        let bundle = Bundle(for: FixtureClientTestCase.self)
+        let url = bundle.url(forResource: "client_fixtures", withExtension: nil)!
+        let credentials = ClientCredential(apiKey: "some_api_key")
+        let config = ClientConfiguration(baseURL: "http://localhst:4000", credentials: credentials)
+        return FixtureClient(fixturesDirectoryURL: url, config: config)
+    }
+
+    func testLoginSuccessfullyAndUpdateToken() {
+        let expectation = self.expectation(description: "Log a user in successfully and updates the client authentication")
+        XCTAssertNil(try! self.testClient.config.credentials.authentication())
+        let client = self.testClient
+        let params = LoginParams(email: "email", password: "password")
+        let request = client.loginClient(withParams: params, callback: { result in
+            defer { expectation.fulfill() }
+            switch result {
+            case let .fail(error: error):
+                XCTFail(error.message)
+            case let .success(data: authenticationToken):
+                XCTAssertEqual(authenticationToken.token, "azJRj09l7jvR8KhTqUs3")
+                XCTAssertEqual(authenticationToken.user!.id, "usr_01cc02x0v98qcctvycfx4vsk8x")
+                XCTAssertNotNil(try! client.config.credentials.authentication())
+            }
+        })
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+}

--- a/Tests/Client/FixtureTests/LogoutFixtureTests.swift
+++ b/Tests/Client/FixtureTests/LogoutFixtureTests.swift
@@ -10,21 +10,13 @@
 import XCTest
 
 class LogoutFixtureTests: FixtureClientTestCase {
-    func testPerformQueryAfterLogout() {
-        let expectation = self.expectation(description: "Check if other queries fail after logout")
+    func testAuthenticationIsInvalidedAfterLogout() {
+        let expectation = self.expectation(description: "Authentication should be nil after logout")
         XCTAssertNotNil(try! self.testClient.config.credentials.authentication())
         let client = self.testClient
         let request = client.logoutClient { _ in
             defer { expectation.fulfill() }
-            do {
-                _ = try client.config.credentials.authentication()
-                XCTFail("Should not be able to encode header after logout")
-            } catch let error as OMGError {
-                switch error {
-                case .configuration(message: _): break
-                default: XCTFail("Should throw a configuration error")
-                }
-            } catch _ {}
+            XCTAssertNil(try! client.config.credentials.authentication())
         }
         XCTAssertNotNil(request)
         waitForExpectations(timeout: 15.0, handler: nil)

--- a/Tests/Client/FixtureTests/client_fixtures/api/user.login.json
+++ b/Tests/Client/FixtureTests/client_fixtures/api/user.login.json
@@ -7,8 +7,8 @@
     "user_id": "usr_01cc02x0v98qcctvycfx4vsk8x",
     "user": {
       "id": "usr_01cc02x0v98qcctvycfx4vsk8x",
-      "provider_user_id": "wijf-fbancomw-dqwjudb",
-      "username": "john.doe@example.com",
+      "provider_user_id": null,
+      "username": null,
       "socket_topic": "user:usr_01cc02x0v98qcctvycfx4vsk8x",
       "metadata": {},
       "encrypted_metadata": {},

--- a/Tests/Client/FixtureTests/client_fixtures/api/user.login.json
+++ b/Tests/Client/FixtureTests/client_fixtures/api/user.login.json
@@ -1,0 +1,19 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "object": "authentication_token",
+    "authentication_token": "azJRj09l7jvR8KhTqUs3",
+    "user_id": "usr_01cc02x0v98qcctvycfx4vsk8x",
+    "user": {
+      "id": "usr_01cc02x0v98qcctvycfx4vsk8x",
+      "provider_user_id": "wijf-fbancomw-dqwjudb",
+      "username": "john.doe@example.com",
+      "socket_topic": "user:usr_01cc02x0v98qcctvycfx4vsk8x",
+      "metadata": {},
+      "encrypted_metadata": {},
+      "created_at": "2018-01-01T00:00:00Z",
+      "updated_at": "2018-01-01T00:00:00Z"
+    }
+  }
+}

--- a/Tests/Core/CodingTests/DecodeTests.swift
+++ b/Tests/Core/CodingTests/DecodeTests.swift
@@ -609,4 +609,15 @@ class DecodeTests: XCTestCase {
             XCTFail(thrownError.localizedDescription)
         }
     }
+
+    func testAuthenticationTokenDecoding() {
+        do {
+            let jsonData = try self.jsonData(withFileName: "authentication_token")
+            let decodedData = try self.jsonDecoder.decode(AuthenticationToken.self, from: jsonData)
+            XCTAssertEqual(decodedData.token, "azJRj09l7jvR8KhTqUs3")
+            XCTAssertEqual(decodedData.user!.id, "usr_01cc02x0v98qcctvycfx4vsk8x")
+        } catch let thrownError {
+            XCTFail(thrownError.localizedDescription)
+        }
+    }
 }

--- a/Tests/Core/CodingTests/DecodeTests.swift
+++ b/Tests/Core/CodingTests/DecodeTests.swift
@@ -615,7 +615,7 @@ class DecodeTests: XCTestCase {
             let jsonData = try self.jsonData(withFileName: "authentication_token")
             let decodedData = try self.jsonDecoder.decode(AuthenticationToken.self, from: jsonData)
             XCTAssertEqual(decodedData.token, "azJRj09l7jvR8KhTqUs3")
-            XCTAssertEqual(decodedData.user!.id, "usr_01cc02x0v98qcctvycfx4vsk8x")
+            XCTAssertEqual(decodedData.user.id, "usr_01cc02x0v98qcctvycfx4vsk8x")
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
         }

--- a/Tests/Core/FixtureTests/FixtureClient.swift
+++ b/Tests/Core/FixtureTests/FixtureClient.swift
@@ -12,12 +12,10 @@ import Foundation
 class FixtureClient: HTTPClient {
     let fixturesDirectoryURL: URL
 
-    init(fixturesDirectoryURL: URL) {
+    init(fixturesDirectoryURL: URL, config: Configuration) {
         self.fixturesDirectoryURL = fixturesDirectoryURL
         super.init()
-        let credentials = ClientCredential(apiKey: "some_api_key", authenticationToken: "some_token")
-        self.config = ClientConfiguration(baseURL: "http://localhost:4000",
-                                          credentials: credentials)
+        self.config = config
     }
 
     @discardableResult

--- a/Tests/Core/FixtureTests/FixtureTestCase.swift
+++ b/Tests/Core/FixtureTests/FixtureTestCase.swift
@@ -13,6 +13,7 @@ class FixtureTestCase: XCTestCase {
     var testClient: FixtureClient {
         let bundle = Bundle(for: FixtureTestCase.self)
         let url = bundle.url(forResource: "core_fixtures", withExtension: nil)!
-        return FixtureClient(fixturesDirectoryURL: url)
+        let config = TestConfiguration()
+        return FixtureClient(fixturesDirectoryURL: url, config: config)
     }
 }

--- a/Tests/Core/FixtureTests/core_fixtures/objects/authentication_token.json
+++ b/Tests/Core/FixtureTests/core_fixtures/objects/authentication_token.json
@@ -1,0 +1,14 @@
+{
+  "authentication_token": "azJRj09l7jvR8KhTqUs3",
+  "user_id": "usr_01cc02x0v98qcctvycfx4vsk8x",
+  "user": {
+    "id": "usr_01cc02x0v98qcctvycfx4vsk8x",
+    "provider_user_id": "wijf-fbancomw-dqwjudb",
+    "username": "john.doe@example.com",
+    "socket_topic": "user:usr_01cc02x0v98qcctvycfx4vsk8x",
+    "metadata": {},
+    "encrypted_metadata": {},
+    "created_at": "2018-01-01T00:00:00Z",
+    "updated_at": "2018-01-01T00:00:00Z"
+  }
+}

--- a/Tests/Core/Helpers/StubGenerator.swift
+++ b/Tests/Core/Helpers/StubGenerator.swift
@@ -93,6 +93,14 @@ class StubGenerator {
                      updatedAt: updatedAt ?? v.updatedAt)
     }
 
+    class func authenticationToken(token: String? = nil,
+                                   user: User? = nil)
+        -> AuthenticationToken {
+        let v: AuthenticationToken = self.stub(forResource: "authentication_token")
+        return AuthenticationToken(token: token ?? v.token,
+                                   user: user ?? v.user)
+    }
+
     class func settings(tokens: [Token]? = nil)
         -> Setting {
         let v: Setting = self.stub(forResource: "setting")

--- a/Tests/Core/ModelTests/AuthenticationTokenTests.swift
+++ b/Tests/Core/ModelTests/AuthenticationTokenTests.swift
@@ -1,0 +1,28 @@
+//
+//  AuthenticationTokenTests.swift
+//  Tests
+//
+//  Created by Mederic Petit on 15/8/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+import XCTest
+
+class AuthenticationTokenTests: XCTestCase {
+    func testEquatable() {
+        let token1 = StubGenerator.authenticationToken(token: "123")
+        let token2 = StubGenerator.authenticationToken(token: "123")
+        let token3 = StubGenerator.authenticationToken(token: "789")
+        XCTAssertEqual(token1, token2)
+        XCTAssertNotEqual(token1, token3)
+    }
+
+    func testHashable() {
+        let token1 = StubGenerator.authenticationToken(token: "123")
+        let token2 = StubGenerator.authenticationToken(token: "123")
+        let set: Set<AuthenticationToken> = [token1, token2]
+        XCTAssertEqual(token1.hashValue, "123".hashValue)
+        XCTAssertEqual(set.count, 1)
+    }
+}

--- a/Tests/Core/TestMocks/TestCredential.swift
+++ b/Tests/Core/TestMocks/TestCredential.swift
@@ -9,6 +9,8 @@
 @testable import OmiseGO
 
 struct TestCredential: Credential {
+    mutating func update(withAuthenticationToken _: AuthenticationToken) {}
+
     func authentication() throws -> String? {
         return "OMGClient \("123:123".data(using: .utf8)!.base64EncodedString())"
     }


### PR DESCRIPTION
Closes #71 

# Overview

This PR adds the client login API to the SDK.

# Changes

- Add `client.loginClient(...)`

# Implementation details

The `ClientCredential` object can now be initialized without a token in order to make queries that don't require authentication.

Upon successful login, the client configuration will be automatically upgraded with the token received so the it will be usable to make authenticated queries.

# Usage

- Initialize a client:
```
let credentials = ClientCredential(apiKey: "api-key")
let config = ClientConfiguration(baseURL: "http://localhost:4000", credentials: credentials)
let client = HTTPClient(config: config)
```
- Perform the login query:
```
let params = LoginParams(email: "email@example.com", password: "password")
client.loginClient(withParams: params) { (result) in
}
```

# Impact

No impact on existing systems
