### PR TITLE
Add list wallets for account API

### DIFF
--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -103,7 +103,7 @@
 		034F1518214F6713002BB513 /* WalletGetParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F1517214F6713002BB513 /* WalletGetParams.swift */; };
 		034F151A214F6AC0002BB513 /* WalletAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F1519214F6AC0002BB513 /* WalletAdminFixtureTests.swift */; };
 		034F151C214F6E8E002BB513 /* RequestAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F151B214F6E8E002BB513 /* RequestAdminFixtureTests.swift */; };
-		034F1520214F8708002BB513 /* WalletGetForUserParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F151F214F8708002BB513 /* WalletGetForUserParams.swift */; };
+		034F1520214F8708002BB513 /* WalletListForUserParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F151F214F8708002BB513 /* WalletListForUserParams.swift */; };
 		034F1523214FA205002BB513 /* SortParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F1522214FA205002BB513 /* SortParams.swift */; };
 		034F1525214FA21B002BB513 /* SearchParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F1524214FA21B002BB513 /* SearchParams.swift */; };
 		034F1527214FA228002BB513 /* PaginationParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034F1526214FA228002BB513 /* PaginationParams.swift */; };
@@ -179,6 +179,7 @@
 		03E72EDD212424B00060E1D7 /* AuthenticationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */; };
 		03E72EDF2124312C0060E1D7 /* AuthenticationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */; };
 		03F2D500212436BB00BC65BB /* LoginFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */; };
+		03F827462150CA7100BD05D6 /* WalletListForAccountParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */; };
 		0722AF18088B1D5B0C533D3A /* Pods_OmiseGO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F3D88392040FB15FD17E51 /* Pods_OmiseGO.framework */; };
 		9AA7A03093BE5106A618E627 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA7D150759B05A9FDA9B003F /* Pods_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -290,7 +291,7 @@
 		034F1517214F6713002BB513 /* WalletGetParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletGetParams.swift; sourceTree = "<group>"; };
 		034F1519214F6AC0002BB513 /* WalletAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAdminFixtureTests.swift; sourceTree = "<group>"; };
 		034F151B214F6E8E002BB513 /* RequestAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAdminFixtureTests.swift; sourceTree = "<group>"; };
-		034F151F214F8708002BB513 /* WalletGetForUserParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletGetForUserParams.swift; sourceTree = "<group>"; };
+		034F151F214F8708002BB513 /* WalletListForUserParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletListForUserParams.swift; sourceTree = "<group>"; };
 		034F1522214FA205002BB513 /* SortParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortParams.swift; sourceTree = "<group>"; };
 		034F1524214FA21B002BB513 /* SearchParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchParams.swift; sourceTree = "<group>"; };
 		034F1526214FA228002BB513 /* PaginationParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationParams.swift; sourceTree = "<group>"; };
@@ -369,6 +370,7 @@
 		03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationToken.swift; sourceTree = "<group>"; };
 		03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenTests.swift; sourceTree = "<group>"; };
 		03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFixtureTests.swift; sourceTree = "<group>"; };
+		03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletListForAccountParams.swift; sourceTree = "<group>"; };
 		16499E8AC99F7FCEE0A0FC0E /* Pods-OmiseGO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.release.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.release.xcconfig"; sourceTree = "<group>"; };
 		47235654A4C773217A4C91D9 /* Pods-OmiseGO.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.debug.xcconfig"; sourceTree = "<group>"; };
 		D2F65698E210E4D7AEBCE81C /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -637,7 +639,8 @@
 			children = (
 				034F1515214F6617002BB513 /* Wallet+Admin.swift */,
 				034F1517214F6713002BB513 /* WalletGetParams.swift */,
-				034F151F214F8708002BB513 /* WalletGetForUserParams.swift */,
+				034F151F214F8708002BB513 /* WalletListForUserParams.swift */,
+				03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1116,6 +1119,7 @@
 				0320EAB1211853010006685C /* APIClientEndpoint.swift in Sources */,
 				0320EABD2119499B0006685C /* TransactionConsumption+Client.swift in Sources */,
 				0379E80021184BC900E65D4F /* JSONResponse.swift in Sources */,
+				03F827462150CA7100BD05D6 /* WalletListForAccountParams.swift in Sources */,
 				0379E81D21184BC900E65D4F /* Codable.swift in Sources */,
 				0379E80A21184BC900E65D4F /* Listenable.swift in Sources */,
 				0379E81621184BC900E65D4F /* HTTPTask.swift in Sources */,
@@ -1142,7 +1146,7 @@
 				0379E81021184BC900E65D4F /* QRScannerViewModel.swift in Sources */,
 				0379E81721184BC900E65D4F /* RequestBuilder.swift in Sources */,
 				0320EAAF211852EB0006685C /* APIAdminEndpoint.swift in Sources */,
-				034F1520214F8708002BB513 /* WalletGetForUserParams.swift in Sources */,
+				034F1520214F8708002BB513 /* WalletListForUserParams.swift in Sources */,
 				0379E81921184BC900E65D4F /* Request.swift in Sources */,
 				0379E81C21184BC900E65D4F /* OMGNumberFormatter.swift in Sources */,
 				0320EABE2119499B0006685C /* Wallet+Client.swift in Sources */,

--- a/Source/Admin/API/APIAdminEndpoint.swift
+++ b/Source/Admin/API/APIAdminEndpoint.swift
@@ -12,6 +12,7 @@ enum APIAdminEndpoint: APIEndpoint {
     case logout
     case getWallet(params: WalletGetParams)
     case getWalletsForUser(params: WalletListForUserParams)
+    case getWalletsForAccount(params: WalletListForAccountParams)
 
     var path: String {
         switch self {
@@ -23,6 +24,8 @@ enum APIAdminEndpoint: APIEndpoint {
             return "/wallet.get"
         case .getWalletsForUser:
             return "/user.get_wallets"
+        case .getWalletsForAccount:
+            return "/account.get_wallets"
         }
     }
 
@@ -33,6 +36,8 @@ enum APIAdminEndpoint: APIEndpoint {
         case let .getWallet(parameters):
             return .requestParameters(parameters: parameters)
         case let .getWalletsForUser(parameters):
+            return .requestParameters(parameters: parameters)
+        case let .getWalletsForAccount(parameters):
             return .requestParameters(parameters: parameters)
         default:
             return .requestPlain

--- a/Source/Admin/Models/Wallet+Admin.swift
+++ b/Source/Admin/Models/Wallet+Admin.swift
@@ -41,16 +41,32 @@ extension Wallet {
 
 extension Wallet: PaginatedListable {
     @discardableResult
-    /// Get all wallets for a user
+    /// Get a paginated list of wallets for a user
     ///
     /// - Parameters:
     ///   - client: An API client.
     ///             This client need to be initialized with a AdminConfiguration struct before being used.
+    ///   - params: The WalletListForUserParams object containing the user id and the pagination informations
     ///   - callback: The closure called when the request is completed
     /// - Returns: An optional cancellable request.
-    public static func getForUser(using client: HTTPAdminAPI,
-                                  params: WalletListForUserParams,
-                                  callback: @escaping Wallet.PaginatedListRequestCallback) -> Wallet.PaginatedListRequest? {
+    public static func listForUser(using client: HTTPAdminAPI,
+                                   params: WalletListForUserParams,
+                                   callback: @escaping Wallet.PaginatedListRequestCallback) -> Wallet.PaginatedListRequest? {
         return self.list(using: client, endpoint: APIAdminEndpoint.getWalletsForUser(params: params), callback: callback)
+    }
+
+    @discardableResult
+    /// Get a paginated list of wallets for an account
+    ///
+    /// - Parameters:
+    ///   - client: An API client.
+    ///             This client need to be initialized with a AdminConfiguration struct before being used.
+    ///   - params: The WalletListForAccountParams object containing the account id and the pagination informations
+    ///   - callback: The closure called when the request is completed
+    /// - Returns: An optional cancellable request.
+    public static func listForAccount(using client: HTTPAdminAPI,
+                                      params: WalletListForAccountParams,
+                                      callback: @escaping Wallet.PaginatedListRequestCallback) -> Wallet.PaginatedListRequest? {
+        return self.list(using: client, endpoint: APIAdminEndpoint.getWalletsForAccount(params: params), callback: callback)
     }
 }

--- a/Source/Admin/Models/WalletListForAccountParams.swift
+++ b/Source/Admin/Models/WalletListForAccountParams.swift
@@ -1,0 +1,47 @@
+//
+//  WalletListForAccountParams.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 18/9/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+/// Represents a structure used to retrieve wallets for a specific user
+public struct WalletListForAccountParams {
+    /// The pagination params
+    public let paginatedListParams: PaginatedListParams<Wallet>
+    /// The account id
+    public let accountId: String
+    /// Query only wallets belonging to the specified account OR also its children
+    public let owned: Bool
+
+    /// Initialize the params used to query a paginated list of wallets belonging to an account from its id
+    ///
+    /// - Parameters:
+    ///   - paginatedListParams: The params to use for the pagination
+    ///   - accountId: The id of the account
+    public init(paginatedListParams: PaginatedListParams<Wallet>,
+                accountId: String,
+                owned: Bool) {
+        self.paginatedListParams = paginatedListParams
+        self.accountId = accountId
+        self.owned = owned
+    }
+}
+
+extension WalletListForAccountParams: APIParameters {
+    private enum CodingKeys: String, CodingKey {
+        case paginatedListParams
+        case accountId = "id"
+        case owned
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try paginatedListParams.encode(to: encoder)
+        try container.encode(accountId, forKey: .accountId)
+        try container.encode(owned, forKey: .owned)
+    }
+}

--- a/Source/Admin/Models/WalletListForUserParams.swift
+++ b/Source/Admin/Models/WalletListForUserParams.swift
@@ -1,5 +1,5 @@
 //
-//  WalletGetForUserParams.swift
+//  WalletListForUserParams.swift
 //  OmiseGO
 //
 //  Created by Mederic Petit on 17/9/18.
@@ -8,8 +8,11 @@
 
 /// Represents a structure used to retrieve wallets for a specific user
 public struct WalletListForUserParams {
+    /// The pagination params
     public let paginatedListParams: PaginatedListParams<Wallet>
+    /// The id of the user
     public let userId: String?
+    /// The provider user id of the user
     public let providerUserId: String?
 
     /// Initialize the params used to query a paginated list of wallets belonging to a user from its userId

--- a/Tests/Admin/APITests/APIAdminEndpointTest.swift
+++ b/Tests/Admin/APITests/APIAdminEndpointTest.swift
@@ -18,12 +18,20 @@ class APIAdminEndpointTest: XCTestCase {
                                                                                  sortBy: .address,
                                                                                  sortDirection: .ascending),
                                 userId: "123")
+    let validWalletListForAccountParams =
+        WalletListForAccountParams(paginatedListParams: PaginatedListParams<Wallet>(page: 1,
+                                                                                    perPage: 1,
+                                                                                    sortBy: .address,
+                                                                                    sortDirection: .ascending),
+                                   accountId: "123",
+                                   owned: false)
 
     func testPath() {
         XCTAssertEqual(APIAdminEndpoint.login(params: self.validLoginParams).path, "/admin.login")
         XCTAssertEqual(APIAdminEndpoint.logout.path, "/me.logout")
         XCTAssertEqual(APIAdminEndpoint.getWallet(params: self.validWalletGetParams).path, "/wallet.get")
         XCTAssertEqual(APIAdminEndpoint.getWalletsForUser(params: self.validWalletListForUserParams).path, "/user.get_wallets")
+        XCTAssertEqual(APIAdminEndpoint.getWalletsForAccount(params: self.validWalletListForAccountParams).path, "/account.get_wallets")
     }
 
     func testTask() {
@@ -40,6 +48,10 @@ class APIAdminEndpointTest: XCTestCase {
         default: XCTFail("Wrong task")
         }
         switch APIAdminEndpoint.getWalletsForUser(params: self.validWalletListForUserParams).task {
+        case .requestParameters: break
+        default: XCTFail("Wrong task")
+        }
+        switch APIAdminEndpoint.getWalletsForAccount(params: self.validWalletListForAccountParams).task {
         case .requestParameters: break
         default: XCTFail("Wrong task")
         }

--- a/Tests/Admin/FixtureTests/WalletAdminFixtureTests.swift
+++ b/Tests/Admin/FixtureTests/WalletAdminFixtureTests.swift
@@ -32,7 +32,7 @@ class WalletAdminFixtureTests: FixtureAdminTestCase {
         let userId = "usr_01cq97a3hgm49h8tw28evv5bg2"
         let paginationParams: PaginatedListParams<Wallet> = PaginatedListParams<Wallet>(page: 1, perPage: 10, sortBy: .address, sortDirection: .ascending)
         let params = WalletListForUserParams(paginatedListParams: paginationParams, userId: userId)
-        let request = Wallet.getForUser(using: self.testClient, params: params) { result in
+        let request = Wallet.listForUser(using: self.testClient, params: params) { result in
             defer { expectation.fulfill() }
             switch result {
             case let .success(data: paginatedWallets):
@@ -44,6 +44,31 @@ class WalletAdminFixtureTests: FixtureAdminTestCase {
                 XCTAssertEqual(wallets.count, 2)
                 XCTAssertEqual(wallets.first!.userId!, userId)
                 XCTAssertEqual(wallets[1].userId!, userId)
+            case let .fail(error: error):
+                XCTFail("\(error)")
+            }
+        }
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+
+    func testGetListForAccount() {
+        let expectation = self.expectation(description: "Get wallets for a specific account")
+        let accountId = "acc_01cnfz5sh5zmhx4xwd6m1rethy"
+        let paginationParams: PaginatedListParams<Wallet> = PaginatedListParams<Wallet>(page: 1, perPage: 10, sortBy: .address, sortDirection: .ascending)
+        let params = WalletListForAccountParams(paginatedListParams: paginationParams, accountId: accountId, owned: false)
+        let request = Wallet.listForAccount(using: self.testClient, params: params) { result in
+            defer { expectation.fulfill() }
+            switch result {
+            case let .success(data: paginatedWallets):
+                let wallets = paginatedWallets.data
+                XCTAssertEqual(paginatedWallets.pagination.currentPage, 1)
+                XCTAssertEqual(paginatedWallets.pagination.perPage, 10)
+                XCTAssertTrue(paginatedWallets.pagination.isFirstPage)
+                XCTAssertTrue(paginatedWallets.pagination.isLastPage)
+                XCTAssertEqual(wallets.count, 2)
+                XCTAssertEqual(wallets.first!.accountId!, accountId)
+                XCTAssertEqual(wallets[1].accountId!, accountId)
             case let .fail(error: error):
                 XCTFail("\(error)")
             }

--- a/Tests/Admin/FixtureTests/admin_fixtures/api/account.get_wallets.json
+++ b/Tests/Admin/FixtureTests/admin_fixtures/api/account.get_wallets.json
@@ -1,0 +1,161 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "pagination": {
+      "per_page": 10,
+      "is_last_page": true,
+      "is_first_page": true,
+      "current_page": 1
+    },
+    "object": "list",
+    "data": [
+      {
+        "user_id": null,
+        "user": null,
+        "updated_at": "2018-08-22T04:44:38.837395Z",
+        "socket_topic": "wallet:ixsz977823599563",
+        "object": "wallet",
+        "name": "primary",
+        "metadata": {},
+        "identifier": "primary",
+        "encrypted_metadata": {},
+        "enabled": true,
+        "created_at": "2018-08-22T04:44:38.837384Z",
+        "balances": [
+          {
+            "token": {
+              "updated_at": "2018-08-22T07:53:13.800904Z",
+              "symbol": "TK1",
+              "subunit_to_unit": 1,
+              "object": "token",
+              "name": "Token 1",
+              "metadata": {},
+              "id": "tok_TK1_01cng9z3a8yn58ts806vbpefxw",
+              "encrypted_metadata": {},
+              "enabled": true,
+              "created_at": "2018-08-22T07:53:13.800896Z"
+            },
+            "object": "balance",
+            "amount": 37585
+          },
+          {
+            "token": {
+              "updated_at": "2018-08-23T07:21:03.542632Z",
+              "symbol": "TK2",
+              "subunit_to_unit": 1,
+              "object": "token",
+              "name": "Token 2",
+              "metadata": {},
+              "id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+              "encrypted_metadata": {},
+              "enabled": true,
+              "created_at": "2018-08-23T07:21:03.542625Z"
+            },
+            "object": "balance",
+            "amount": 9999999469
+          }
+        ],
+        "address": "ixsz977823599563",
+        "account_id": "acc_01cnfz5sh5zmhx4xwd6m1rethy",
+        "account": {
+          "updated_at": "2018-08-24T09:47:29.116420Z",
+          "socket_topic": "account:acc_01cnfz5sh5zmhx4xwd6m1rethy",
+          "parent_id": null,
+          "object": "account",
+          "name": "Account 1",
+          "metadata": {},
+          "master": true,
+          "id": "acc_01cnfz5sh5zmhx4xwd6m1rethy",
+          "encrypted_metadata": {},
+          "description": "Master Account",
+          "created_at": "2018-08-22T04:44:38.823385Z",
+          "category_ids": [],
+          "categories": {
+            "object": "list",
+            "data": []
+          },
+          "avatar": {
+            "thumb": null,
+            "small": null,
+            "original": null,
+            "large": null
+          }
+        }
+      },
+      {
+        "user_id": null,
+        "user": null,
+        "updated_at": "2018-08-22T04:44:38.839533Z",
+        "socket_topic": "wallet:gaxv776652797936",
+        "object": "wallet",
+        "name": "burn",
+        "metadata": {},
+        "identifier": "burn",
+        "encrypted_metadata": {},
+        "enabled": true,
+        "created_at": "2018-08-22T04:44:38.839524Z",
+        "balances": [
+          {
+            "token": {
+              "updated_at": "2018-08-22T07:53:13.800904Z",
+              "symbol": "TK1",
+              "subunit_to_unit": 1,
+              "object": "token",
+              "name": "Token 1",
+              "metadata": {},
+              "id": "tok_TK1_01cng9z3a8yn58ts806vbpefxw",
+              "encrypted_metadata": {},
+              "enabled": true,
+              "created_at": "2018-08-22T07:53:13.800896Z"
+            },
+            "object": "balance",
+            "amount": 0
+          },
+          {
+            "token": {
+              "updated_at": "2018-08-23T07:21:03.542632Z",
+              "symbol": "TK2",
+              "subunit_to_unit": 1,
+              "object": "token",
+              "name": "Token 2",
+              "metadata": {},
+              "id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+              "encrypted_metadata": {},
+              "enabled": true,
+              "created_at": "2018-08-23T07:21:03.542625Z"
+            },
+            "object": "balance",
+            "amount": 0
+          }
+        ],
+        "address": "gaxv776652797936",
+        "account_id": "acc_01cnfz5sh5zmhx4xwd6m1rethy",
+        "account": {
+          "updated_at": "2018-08-24T09:47:29.116420Z",
+          "socket_topic": "account:acc_01cnfz5sh5zmhx4xwd6m1rethy",
+          "parent_id": null,
+          "object": "account",
+          "name": "Account 1",
+          "metadata": {},
+          "master": true,
+          "id": "acc_01cnfz5sh5zmhx4xwd6m1rethy",
+          "encrypted_metadata": {},
+          "description": "Master Account",
+          "created_at": "2018-08-22T04:44:38.823385Z",
+          "category_ids": [],
+          "categories": {
+            "object": "list",
+            "data": []
+          },
+          "avatar": {
+            "thumb": null,
+            "small": null,
+            "original": null,
+            "large": null
+          }
+        }
+      }
+    ]
+  }
+}

--- a/Tests/Core/CodingTests/EncodeTests.swift
+++ b/Tests/Core/CodingTests/EncodeTests.swift
@@ -284,7 +284,7 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData,
                                   encoding: .utf8)!, """
-                                                                                    {"formatted_id":"|0a8a4a98-794b-419e-b92d-514e83657e75"}
+                                                                                            {"formatted_id":"|0a8a4a98-794b-419e-b92d-514e83657e75"}
             """.uglifiedEncodedString())
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
@@ -467,7 +467,7 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData,
                                   encoding: .utf8)!, """
-                                                                                    {"id":"0a8a4a98-794b-419e-b92d-514e83657e75"}
+                                                                                            {"id":"0a8a4a98-794b-419e-b92d-514e83657e75"}
             """.uglifiedEncodedString())
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
@@ -617,6 +617,34 @@ class EncodeTests: XCTestCase {
                     "sort_dir":"asc",
                     "sort_by":"address",
                     "page":1
+                }
+            """.uglifiedEncodedString())
+        } catch let thrownError {
+            XCTFail(thrownError.localizedDescription)
+        }
+    }
+
+    func testWalletListForAccountParamsEncoding() {
+        do {
+            let walletParams = WalletListForAccountParams(
+                paginatedListParams: StubGenerator.paginatedListParams(
+                    searchTerm: "test",
+                    sortBy: .address,
+                    sortDirection: .ascending),
+                accountId: "123",
+                owned: true)
+            let encodedData = try self.encoder.encode(walletParams)
+            let encodedPayload = try! walletParams.encodedPayload()
+            XCTAssertEqual(encodedData, encodedPayload)
+            XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
+                {
+                    "per_page":20,
+                    "page":1,
+                    "id":"123",
+                    "owned": true,
+                    "sort_dir":"asc",
+                    "search_term":"test",
+                    "sort_by":"address"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {


### PR DESCRIPTION
Closes #85 

# Overview

This PR adds the list wallets for an account API.

# Usage

```
        let paginationParams: PaginatedListParams<Wallet> = PaginatedListParams<Wallet>(page: 1, perPage: 10, sortBy: .address, sortDirection: .ascending)
        let params = WalletListForAccountParams(paginatedListParams: paginationParams, accountId:"acc_01cnfz5sh5zmhx4xwd6m1rethy", owned: false)
        Wallet.listForAccount(using: self.apiClient, params: params) { result in
            switch result {
            case let .success(data: paginatedWallets):
                let wallets = paginatedWallets.data
                print(wallets)
            case let .fail(error: error): print(error)
            }
        }
``` 
