### PR TITLE
Add list accounts API

### DIFF
--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -180,6 +180,8 @@
 		03E72EDF2124312C0060E1D7 /* AuthenticationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */; };
 		03F2D500212436BB00BC65BB /* LoginFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */; };
 		03F827462150CA7100BD05D6 /* WalletListForAccountParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */; };
+		03F827482150F45E00BD05D6 /* Account+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827472150F45E00BD05D6 /* Account+Admin.swift */; };
+		03F8274A2150FA6C00BD05D6 /* AccountAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */; };
 		0722AF18088B1D5B0C533D3A /* Pods_OmiseGO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F3D88392040FB15FD17E51 /* Pods_OmiseGO.framework */; };
 		9AA7A03093BE5106A618E627 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA7D150759B05A9FDA9B003F /* Pods_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -371,6 +373,8 @@
 		03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenTests.swift; sourceTree = "<group>"; };
 		03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFixtureTests.swift; sourceTree = "<group>"; };
 		03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletListForAccountParams.swift; sourceTree = "<group>"; };
+		03F827472150F45E00BD05D6 /* Account+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+Admin.swift"; sourceTree = "<group>"; };
+		03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAdminFixtureTests.swift; sourceTree = "<group>"; };
 		16499E8AC99F7FCEE0A0FC0E /* Pods-OmiseGO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.release.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.release.xcconfig"; sourceTree = "<group>"; };
 		47235654A4C773217A4C91D9 /* Pods-OmiseGO.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.debug.xcconfig"; sourceTree = "<group>"; };
 		D2F65698E210E4D7AEBCE81C /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -638,6 +642,7 @@
 			isa = PBXGroup;
 			children = (
 				034F1515214F6617002BB513 /* Wallet+Admin.swift */,
+				03F827472150F45E00BD05D6 /* Account+Admin.swift */,
 				034F1517214F6713002BB513 /* WalletGetParams.swift */,
 				034F151F214F8708002BB513 /* WalletListForUserParams.swift */,
 				03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */,
@@ -856,6 +861,7 @@
 				03AB7ED2214BC04C00C80D8E /* LoginAdminFixtureTests.swift */,
 				034F1512214F562D002BB513 /* LogoutAdminFixtureTests.swift */,
 				034F1519214F6AC0002BB513 /* WalletAdminFixtureTests.swift */,
+				03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */,
 			);
 			path = FixtureTests;
 			sourceTree = "<group>";
@@ -1112,6 +1118,7 @@
 				0379E80B21184BC900E65D4F /* Listable.swift in Sources */,
 				0379E81321184BC900E65D4F /* QRScannerViewController.swift in Sources */,
 				0379E80D21184BC900E65D4F /* QRReader.swift in Sources */,
+				03F827482150F45E00BD05D6 /* Account+Admin.swift in Sources */,
 				034F1516214F6617002BB513 /* Wallet+Admin.swift in Sources */,
 				0379E7FB21184BC900E65D4F /* Balance.swift in Sources */,
 				0320EAC32119667B0006685C /* ClientCredential.swift in Sources */,
@@ -1267,6 +1274,7 @@
 				032CEDCF211D3D5300E44445 /* QRGeneratorTests.swift in Sources */,
 				03210BA321267AF400B56295 /* FixtureClientAPI.swift in Sources */,
 				0380AAEB212D311B006B2193 /* SignupFixtureTests.swift in Sources */,
+				03F8274A2150FA6C00BD05D6 /* AccountAdminFixtureTests.swift in Sources */,
 				032CEE27211D3D5300E44445 /* APIClientEndpointTest.swift in Sources */,
 				032CEDDF211D3D5300E44445 /* CredentialEncoderTests.swift in Sources */,
 				032CEDCD211D3D5300E44445 /* ToolsTests.swift in Sources */,

--- a/Source/Admin/API/APIAdminEndpoint.swift
+++ b/Source/Admin/API/APIAdminEndpoint.swift
@@ -13,6 +13,7 @@ enum APIAdminEndpoint: APIEndpoint {
     case getWallet(params: WalletGetParams)
     case getWalletsForUser(params: WalletListForUserParams)
     case getWalletsForAccount(params: WalletListForAccountParams)
+    case getAccounts(params: PaginatedListParams<Account>)
 
     var path: String {
         switch self {
@@ -26,6 +27,8 @@ enum APIAdminEndpoint: APIEndpoint {
             return "/user.get_wallets"
         case .getWalletsForAccount:
             return "/account.get_wallets"
+        case .getAccounts:
+            return "/account.all"
         }
     }
 
@@ -38,6 +41,8 @@ enum APIAdminEndpoint: APIEndpoint {
         case let .getWalletsForUser(parameters):
             return .requestParameters(parameters: parameters)
         case let .getWalletsForAccount(parameters):
+            return .requestParameters(parameters: parameters)
+        case let .getAccounts(parameters):
             return .requestParameters(parameters: parameters)
         default:
             return .requestPlain

--- a/Source/Admin/Models/Account+Admin.swift
+++ b/Source/Admin/Models/Account+Admin.swift
@@ -1,0 +1,42 @@
+//
+//  Account+Admin.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 18/9/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+extension Account: Searchable {
+    public enum SearchableFields: String, KeyEncodable {
+        case id
+        case name
+        case description
+    }
+}
+
+extension Account: Sortable {
+    public enum SortableFields: String, KeyEncodable {
+        case id
+        case name
+        case description
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+}
+
+extension Account: PaginatedListable {
+    @discardableResult
+    /// Get a paginated list of accounts
+    ///
+    /// - Parameters:
+    ///   - client: An API client.
+    ///             This client need to be initialized with a AdminConfiguration struct before being used.
+    ///   - params: The pagination params object to use to scope the results
+    ///   - callback: The closure called when the request is completed
+    /// - Returns: An optional cancellable request.
+    public static func list(using client: HTTPAdminAPI,
+                            params: PaginatedListParams<Account>,
+                            callback: @escaping Account.PaginatedListRequestCallback) -> Account.PaginatedListRequest? {
+        return self.list(using: client, endpoint: APIAdminEndpoint.getAccounts(params: params), callback: callback)
+    }
+}

--- a/Tests/Admin/APITests/APIAdminEndpointTest.swift
+++ b/Tests/Admin/APITests/APIAdminEndpointTest.swift
@@ -25,6 +25,7 @@ class APIAdminEndpointTest: XCTestCase {
                                                                                     sortDirection: .ascending),
                                    accountId: "123",
                                    owned: false)
+    let validGetAccountsParams = PaginatedListParams<Account>(page: 1, perPage: 1, sortBy: .name, sortDirection: .ascending)
 
     func testPath() {
         XCTAssertEqual(APIAdminEndpoint.login(params: self.validLoginParams).path, "/admin.login")
@@ -32,6 +33,7 @@ class APIAdminEndpointTest: XCTestCase {
         XCTAssertEqual(APIAdminEndpoint.getWallet(params: self.validWalletGetParams).path, "/wallet.get")
         XCTAssertEqual(APIAdminEndpoint.getWalletsForUser(params: self.validWalletListForUserParams).path, "/user.get_wallets")
         XCTAssertEqual(APIAdminEndpoint.getWalletsForAccount(params: self.validWalletListForAccountParams).path, "/account.get_wallets")
+        XCTAssertEqual(APIAdminEndpoint.getAccounts(params: self.validGetAccountsParams).path, "/account.all")
     }
 
     func testTask() {
@@ -52,6 +54,10 @@ class APIAdminEndpointTest: XCTestCase {
         default: XCTFail("Wrong task")
         }
         switch APIAdminEndpoint.getWalletsForAccount(params: self.validWalletListForAccountParams).task {
+        case .requestParameters: break
+        default: XCTFail("Wrong task")
+        }
+        switch APIAdminEndpoint.getAccounts(params: self.validGetAccountsParams).task {
         case .requestParameters: break
         default: XCTFail("Wrong task")
         }

--- a/Tests/Admin/FixtureTests/AccountAdminFixtureTests.swift
+++ b/Tests/Admin/FixtureTests/AccountAdminFixtureTests.swift
@@ -1,0 +1,35 @@
+//
+//  AccountAdminFixtureTests.swift
+//  Tests
+//
+//  Created by Mederic Petit on 18/9/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+import XCTest
+
+class AccountAdminFixtureTests: FixtureAdminTestCase {
+    func testGetListOfAccounts() {
+        let expectation = self.expectation(description: "List accounts")
+        let params: PaginatedListParams<Account> = PaginatedListParams<Account>(page: 1, perPage: 10, sortBy: .name, sortDirection: .ascending)
+        let request = Account.list(using: self.testClient, params: params) { (result) in
+            defer { expectation.fulfill() }
+            switch result {
+            case let .success(data: paginatedAccounts):
+                let accounts = paginatedAccounts.data
+                XCTAssertEqual(paginatedAccounts.pagination.currentPage, 1)
+                XCTAssertEqual(paginatedAccounts.pagination.perPage, 10)
+                XCTAssertTrue(paginatedAccounts.pagination.isFirstPage)
+                XCTAssertTrue(paginatedAccounts.pagination.isLastPage)
+                XCTAssertEqual(accounts.count, 2)
+                XCTAssertEqual(accounts.first!.id, "acc_01cnfz5sh5zmhx4xwd6m1rethy")
+                XCTAssertEqual(accounts[1].id, "acc_01cnnna53f35n80pnmbf730s29")
+            case let .fail(error: error):
+                XCTFail("\(error)")
+            }
+        }
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+}

--- a/Tests/Admin/FixtureTests/admin_fixtures/api/account.all.json
+++ b/Tests/Admin/FixtureTests/admin_fixtures/api/account.all.json
@@ -1,0 +1,63 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "pagination": {
+      "per_page": 10,
+      "is_last_page": true,
+      "is_first_page": true,
+      "current_page": 1
+    },
+    "object": "list",
+    "data": [
+      {
+        "updated_at": "2018-08-24T09:47:29.116420Z",
+        "socket_topic": "account:acc_01cnfz5sh5zmhx4xwd6m1rethy",
+        "parent_id": null,
+        "object": "account",
+        "name": "Account 1",
+        "metadata": {},
+        "master": true,
+        "id": "acc_01cnfz5sh5zmhx4xwd6m1rethy",
+        "encrypted_metadata": {},
+        "description": "Master Account",
+        "created_at": "2018-08-22T04:44:38.823385Z",
+        "category_ids": [],
+        "categories": {
+          "object": "list",
+          "data": []
+        },
+        "avatar": {
+          "thumb": null,
+          "small": null,
+          "original": null,
+          "large": null
+        }
+      },
+      {
+        "updated_at": "2018-08-24T09:47:42.575342Z",
+        "socket_topic": "account:acc_01cnnna53f35n80pnmbf730s29",
+        "parent_id": "acc_01cnfz5sh5zmhx4xwd6m1rethy",
+        "object": "account",
+        "name": "Account 2",
+        "metadata": {},
+        "master": false,
+        "id": "acc_01cnnna53f35n80pnmbf730s29",
+        "encrypted_metadata": {},
+        "description": null,
+        "created_at": "2018-08-24T09:47:42.575319Z",
+        "category_ids": [],
+        "categories": {
+          "object": "list",
+          "data": []
+        },
+        "avatar": {
+          "thumb": null,
+          "small": null,
+          "original": null,
+          "large": null
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #84 

# Overview

This PR adds the list accounts API.

# Usage

```
        let params: PaginatedListParams<Account> = PaginatedListParams<Account>(page: 1, perPage: 10, sortBy: .name, sortDirection: .ascending)
        Account.list(using: self.apiClient, params: params) { (result) in
            switch result {
            case let .success(data: paginatedAccounts):
                let accounts = paginatedAccounts.data
                print(accounts)
            case let .fail(error: error): print(error)
            }
        }
```