### PR TITLE
Add list transactions API

### DIFF
--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		03F827462150CA7100BD05D6 /* WalletListForAccountParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */; };
 		03F827482150F45E00BD05D6 /* Account+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827472150F45E00BD05D6 /* Account+Admin.swift */; };
 		03F8274A2150FA6C00BD05D6 /* AccountAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */; };
+		03F8274C21523FCC00BD05D6 /* Transaction+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F8274B21523FCC00BD05D6 /* Transaction+Admin.swift */; };
+		03F8274E215245F800BD05D6 /* TransactionAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F8274D215245F800BD05D6 /* TransactionAdminFixtureTests.swift */; };
 		0722AF18088B1D5B0C533D3A /* Pods_OmiseGO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F3D88392040FB15FD17E51 /* Pods_OmiseGO.framework */; };
 		9AA7A03093BE5106A618E627 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA7D150759B05A9FDA9B003F /* Pods_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -375,6 +377,8 @@
 		03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletListForAccountParams.swift; sourceTree = "<group>"; };
 		03F827472150F45E00BD05D6 /* Account+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+Admin.swift"; sourceTree = "<group>"; };
 		03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAdminFixtureTests.swift; sourceTree = "<group>"; };
+		03F8274B21523FCC00BD05D6 /* Transaction+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transaction+Admin.swift"; sourceTree = "<group>"; };
+		03F8274D215245F800BD05D6 /* TransactionAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionAdminFixtureTests.swift; sourceTree = "<group>"; };
 		16499E8AC99F7FCEE0A0FC0E /* Pods-OmiseGO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.release.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.release.xcconfig"; sourceTree = "<group>"; };
 		47235654A4C773217A4C91D9 /* Pods-OmiseGO.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.debug.xcconfig"; sourceTree = "<group>"; };
 		D2F65698E210E4D7AEBCE81C /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -643,6 +647,7 @@
 			children = (
 				034F1515214F6617002BB513 /* Wallet+Admin.swift */,
 				03F827472150F45E00BD05D6 /* Account+Admin.swift */,
+				03F8274B21523FCC00BD05D6 /* Transaction+Admin.swift */,
 				034F1517214F6713002BB513 /* WalletGetParams.swift */,
 				034F151F214F8708002BB513 /* WalletListForUserParams.swift */,
 				03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */,
@@ -859,6 +864,7 @@
 				03AB7ED1214BC04C00C80D8E /* FixtureAdminAPI.swift */,
 				034F151B214F6E8E002BB513 /* RequestAdminFixtureTests.swift */,
 				03AB7ED2214BC04C00C80D8E /* LoginAdminFixtureTests.swift */,
+				03F8274D215245F800BD05D6 /* TransactionAdminFixtureTests.swift */,
 				034F1512214F562D002BB513 /* LogoutAdminFixtureTests.swift */,
 				034F1519214F6AC0002BB513 /* WalletAdminFixtureTests.swift */,
 				03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */,
@@ -1155,6 +1161,7 @@
 				0320EAAF211852EB0006685C /* APIAdminEndpoint.swift in Sources */,
 				034F1520214F8708002BB513 /* WalletListForUserParams.swift in Sources */,
 				0379E81921184BC900E65D4F /* Request.swift in Sources */,
+				03F8274C21523FCC00BD05D6 /* Transaction+Admin.swift in Sources */,
 				0379E81C21184BC900E65D4F /* OMGNumberFormatter.swift in Sources */,
 				0320EABE2119499B0006685C /* Wallet+Client.swift in Sources */,
 				0379E80821184BC900E65D4F /* Wallet.swift in Sources */,
@@ -1204,6 +1211,7 @@
 				03AB7ED4214BC04D00C80D8E /* APIAdminEndpointTest.swift in Sources */,
 				032CEDDC211D3D5300E44445 /* APIErrorTests.swift in Sources */,
 				032CEE3C211D3D5300E44445 /* AuthenticationLiveTests.swift in Sources */,
+				03F8274E215245F800BD05D6 /* TransactionAdminFixtureTests.swift in Sources */,
 				032CEE20211D3D5300E44445 /* FixtureClient.swift in Sources */,
 				032CEDFB211D3D5300E44445 /* DecodingFixtureTests.swift in Sources */,
 				032CEDDA211D3D5300E44445 /* EncodeTests.swift in Sources */,

--- a/Source/Admin/API/APIAdminEndpoint.swift
+++ b/Source/Admin/API/APIAdminEndpoint.swift
@@ -14,6 +14,7 @@ enum APIAdminEndpoint: APIEndpoint {
     case getWalletsForUser(params: WalletListForUserParams)
     case getWalletsForAccount(params: WalletListForAccountParams)
     case getAccounts(params: PaginatedListParams<Account>)
+    case getTransactions(params: PaginatedListParams<Transaction>)
 
     var path: String {
         switch self {
@@ -29,6 +30,8 @@ enum APIAdminEndpoint: APIEndpoint {
             return "/account.get_wallets"
         case .getAccounts:
             return "/account.all"
+        case .getTransactions:
+            return "/transaction.all"
         }
     }
 
@@ -43,6 +46,8 @@ enum APIAdminEndpoint: APIEndpoint {
         case let .getWalletsForAccount(parameters):
             return .requestParameters(parameters: parameters)
         case let .getAccounts(parameters):
+            return .requestParameters(parameters: parameters)
+        case let .getTransactions(parameters):
             return .requestParameters(parameters: parameters)
         default:
             return .requestPlain

--- a/Source/Admin/Models/Transaction+Admin.swift
+++ b/Source/Admin/Models/Transaction+Admin.swift
@@ -1,0 +1,24 @@
+//
+//  Transaction+Admin.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 19/9/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+extension Transaction {
+    @discardableResult
+    /// Get a paginated list of transactions
+    ///
+    /// - Parameters:
+    ///   - client: An API client.
+    ///             This client need to be initialized with a ClientConfiguration struct before being used.
+    ///   - params: The PaginatedListParams<Transaction> object to use to scope the results
+    ///   - callback: The closure called when the request is completed
+    /// - Returns: An optional cancellable request.
+    public static func list(using client: HTTPAdminAPI,
+                            params: PaginatedListParams<Transaction>,
+                            callback: @escaping Transaction.PaginatedListRequestCallback) -> Transaction.PaginatedListRequest? {
+        return self.list(using: client, endpoint: APIAdminEndpoint.getTransactions(params: params), callback: callback)
+    }
+}

--- a/Tests/Admin/APITests/APIAdminEndpointTest.swift
+++ b/Tests/Admin/APITests/APIAdminEndpointTest.swift
@@ -26,6 +26,7 @@ class APIAdminEndpointTest: XCTestCase {
                                    accountId: "123",
                                    owned: false)
     let validGetAccountsParams = PaginatedListParams<Account>(page: 1, perPage: 1, sortBy: .name, sortDirection: .ascending)
+    let validGetTransactionsParams = PaginatedListParams<Transaction>(page: 1, perPage: 1, sortBy: .status, sortDirection: .ascending)
 
     func testPath() {
         XCTAssertEqual(APIAdminEndpoint.login(params: self.validLoginParams).path, "/admin.login")
@@ -34,6 +35,7 @@ class APIAdminEndpointTest: XCTestCase {
         XCTAssertEqual(APIAdminEndpoint.getWalletsForUser(params: self.validWalletListForUserParams).path, "/user.get_wallets")
         XCTAssertEqual(APIAdminEndpoint.getWalletsForAccount(params: self.validWalletListForAccountParams).path, "/account.get_wallets")
         XCTAssertEqual(APIAdminEndpoint.getAccounts(params: self.validGetAccountsParams).path, "/account.all")
+        XCTAssertEqual(APIAdminEndpoint.getTransactions(params: self.validGetTransactionsParams).path, "/transaction.all")
     }
 
     func testTask() {
@@ -58,6 +60,10 @@ class APIAdminEndpointTest: XCTestCase {
         default: XCTFail("Wrong task")
         }
         switch APIAdminEndpoint.getAccounts(params: self.validGetAccountsParams).task {
+        case .requestParameters: break
+        default: XCTFail("Wrong task")
+        }
+        switch APIAdminEndpoint.getTransactions(params: self.validGetTransactionsParams).task {
         case .requestParameters: break
         default: XCTFail("Wrong task")
         }

--- a/Tests/Admin/FixtureTests/AccountAdminFixtureTests.swift
+++ b/Tests/Admin/FixtureTests/AccountAdminFixtureTests.swift
@@ -13,7 +13,7 @@ class AccountAdminFixtureTests: FixtureAdminTestCase {
     func testGetListOfAccounts() {
         let expectation = self.expectation(description: "List accounts")
         let params: PaginatedListParams<Account> = PaginatedListParams<Account>(page: 1, perPage: 10, sortBy: .name, sortDirection: .ascending)
-        let request = Account.list(using: self.testClient, params: params) { (result) in
+        let request = Account.list(using: self.testClient, params: params) { result in
             defer { expectation.fulfill() }
             switch result {
             case let .success(data: paginatedAccounts):

--- a/Tests/Admin/FixtureTests/TransactionAdminFixtureTests.swift
+++ b/Tests/Admin/FixtureTests/TransactionAdminFixtureTests.swift
@@ -1,0 +1,34 @@
+//
+//  TransactionAdminFixtureTests.swift
+//  Tests
+//
+//  Created by Mederic Petit on 19/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+import XCTest
+
+class TransactionAdminFixtureTests: FixtureAdminTestCase {
+    func testGetListOfTransactions() {
+        let expectation = self.expectation(description: "Get the list of transactions")
+        let params = PaginatedListParams<Transaction>(page: 1,
+                                                      perPage: 10,
+                                                      sortBy: .to,
+                                                      sortDirection: .ascending)
+        let request =
+            Transaction.list(using: self.testClient, params: params) { result in
+                defer { expectation.fulfill() }
+                switch result {
+                case let .success(data: paginatedList):
+                    let transactions = paginatedList.data
+                    XCTAssertEqual(transactions.first?.id, "txn_01cqr309xnwa2qwdk4dqaqrbs6")
+                    XCTAssertEqual(transactions[1].id, "txn_01cqr2yx2ns2kdysat3h7075a0")
+                case let .fail(error: error):
+                    XCTFail("\(error)")
+                }
+            }
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+}

--- a/Tests/Admin/FixtureTests/admin_fixtures/api/transaction.all.json
+++ b/Tests/Admin/FixtureTests/admin_fixtures/api/transaction.all.json
@@ -1,0 +1,217 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "pagination": {
+      "per_page": 10,
+      "is_last_page": false,
+      "is_first_page": true,
+      "current_page": 1
+    },
+    "object": "list",
+    "data": [
+      {
+        "updated_at": "2018-09-19T04:56:52.429167Z",
+        "to": {
+          "user_id": "usr_01cq97a3hgm49h8tw28evv5bg2",
+          "user": {
+            "username": null,
+            "updated_at": "2018-09-13T10:23:39.833617Z",
+            "socket_topic": "user:usr_01cq97a3hgm49h8tw28evv5bg2",
+            "provider_user_id": null,
+            "object": "user",
+            "metadata": {},
+            "id": "usr_01cq97a3hgm49h8tw28evv5bg2",
+            "encrypted_metadata": {},
+            "email": "user@example.com",
+            "created_at": "2018-09-13T10:23:31.376373Z",
+            "avatar": {
+              "thumb": null,
+              "small": null,
+              "original": null,
+              "large": null
+            }
+          },
+          "token_id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+          "token": {
+            "updated_at": "2018-08-23T07:21:03.542632Z",
+            "symbol": "TK2",
+            "subunit_to_unit": 1,
+            "object": "token",
+            "name": "Token 2",
+            "metadata": {},
+            "id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+            "encrypted_metadata": {},
+            "enabled": true,
+            "created_at": "2018-08-23T07:21:03.542625Z"
+          },
+          "object": "transaction_source",
+          "amount": 5,
+          "address": "fzpi652664408105",
+          "account_id": null,
+          "account": null
+        },
+        "status": "confirmed",
+        "object": "transaction",
+        "metadata": {},
+        "idempotency_token": "wkd39y3bdn",
+        "id": "txn_01cqr309xnwa2qwdk4dqaqrbs6",
+        "from": {
+          "user_id": "usr_01cnggq88jyfpvhxxkehph6v5h",
+          "user": {
+            "username": null,
+            "updated_at": "2018-08-22T09:51:16.754145Z",
+            "socket_topic": "user:usr_01cnggq88jyfpvhxxkehph6v5h",
+            "provider_user_id": null,
+            "object": "user",
+            "metadata": {},
+            "id": "usr_01cnggq88jyfpvhxxkehph6v5h",
+            "encrypted_metadata": {},
+            "email": "user1@example.com",
+            "created_at": "2018-08-22T09:51:16.754122Z",
+            "avatar": {
+              "thumb": null,
+              "small": null,
+              "original": null,
+              "large": null
+            }
+          },
+          "token_id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+          "token": {
+            "updated_at": "2018-08-23T07:21:03.542632Z",
+            "symbol": "TK2",
+            "subunit_to_unit": 1,
+            "object": "token",
+            "name": "Token 2",
+            "metadata": {},
+            "id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+            "encrypted_metadata": {},
+            "enabled": true,
+            "created_at": "2018-08-23T07:21:03.542625Z"
+          },
+          "object": "transaction_source",
+          "amount": 5,
+          "address": "eyvq483844336634",
+          "account_id": null,
+          "account": null
+        },
+        "exchange": {
+          "rate": null,
+          "object": "exchange",
+          "exchange_wallet_address": null,
+          "exchange_wallet": null,
+          "exchange_pair_id": null,
+          "exchange_pair": null,
+          "exchange_account_id": null,
+          "exchange_account": null,
+          "calculated_at": null
+        },
+        "error_description": null,
+        "error_code": null,
+        "encrypted_metadata": {},
+        "created_at": "2018-09-19T04:56:52.405884Z"
+      },
+      {
+        "updated_at": "2018-09-19T04:56:06.511808Z",
+        "to": {
+          "user_id": "usr_01cq97a3hgm49h8tw28evv5bg2",
+          "user": {
+            "username": null,
+            "updated_at": "2018-09-13T10:23:39.833617Z",
+            "socket_topic": "user:usr_01cq97a3hgm49h8tw28evv5bg2",
+            "provider_user_id": null,
+            "object": "user",
+            "metadata": {},
+            "id": "usr_01cq97a3hgm49h8tw28evv5bg2",
+            "encrypted_metadata": {},
+            "email": "user@example.com",
+            "created_at": "2018-09-13T10:23:31.376373Z",
+            "avatar": {
+              "thumb": null,
+              "small": null,
+              "original": null,
+              "large": null
+            }
+          },
+          "token_id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+          "token": {
+            "updated_at": "2018-08-23T07:21:03.542632Z",
+            "symbol": "TK2",
+            "subunit_to_unit": 1,
+            "object": "token",
+            "name": "Token 2",
+            "metadata": {},
+            "id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+            "encrypted_metadata": {},
+            "enabled": true,
+            "created_at": "2018-08-23T07:21:03.542625Z"
+          },
+          "object": "transaction_source",
+          "amount": 5,
+          "address": "fzpi652664408105",
+          "account_id": null,
+          "account": null
+        },
+        "status": "confirmed",
+        "object": "transaction",
+        "metadata": {},
+        "idempotency_token": "5reo665wcko",
+        "id": "txn_01cqr2yx2ns2kdysat3h7075a0",
+        "from": {
+          "user_id": "usr_01cnggq88jyfpvhxxkehph6v5h",
+          "user": {
+            "username": null,
+            "updated_at": "2018-08-22T09:51:16.754145Z",
+            "socket_topic": "user:usr_01cnggq88jyfpvhxxkehph6v5h",
+            "provider_user_id": null,
+            "object": "user",
+            "metadata": {},
+            "id": "usr_01cnggq88jyfpvhxxkehph6v5h",
+            "encrypted_metadata": {},
+            "email": "user1@example.com",
+            "created_at": "2018-08-22T09:51:16.754122Z",
+            "avatar": {
+              "thumb": null,
+              "small": null,
+              "original": null,
+              "large": null
+            }
+          },
+          "token_id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+          "token": {
+            "updated_at": "2018-08-23T07:21:03.542632Z",
+            "symbol": "TK2",
+            "subunit_to_unit": 1,
+            "object": "token",
+            "name": "Token 2",
+            "metadata": {},
+            "id": "tok_TK2_01cnjtgx9p89p9g1pa2qjzk9mf",
+            "encrypted_metadata": {},
+            "enabled": true,
+            "created_at": "2018-08-23T07:21:03.542625Z"
+          },
+          "object": "transaction_source",
+          "amount": 5,
+          "address": "eyvq483844336634",
+          "account_id": null,
+          "account": null
+        },
+        "exchange": {
+          "rate": null,
+          "object": "exchange",
+          "exchange_wallet_address": null,
+          "exchange_wallet": null,
+          "exchange_pair_id": null,
+          "exchange_pair": null,
+          "exchange_account_id": null,
+          "exchange_account": null,
+          "calculated_at": null
+        },
+        "error_description": null,
+        "error_code": null,
+        "encrypted_metadata": {},
+        "created_at": "2018-09-19T04:56:06.485448Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #83 

# Overview

This PR adds the list transactions API.

# Usage

```
        let params: PaginatedListParams<Transaction> = PaginatedListParams<Transaction>(page: 1, perPage: 10, sortBy: .status, sortDirection: .ascending)
        Transaction.list(using: self.apiClient, params: params) { (result) in
            switch result {
            case let .success(data: paginatedTransactions):
                let transactions = paginatedTransactions.data
                print(transactions)
            case let .fail(error: error): print(error)
            }
        }
```