### PR TITLE
Add create transaction admin API

### DIFF
--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		03F8274A2150FA6C00BD05D6 /* AccountAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */; };
 		03F8274C21523FCC00BD05D6 /* Transaction+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F8274B21523FCC00BD05D6 /* Transaction+Admin.swift */; };
 		03F8274E215245F800BD05D6 /* TransactionAdminFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F8274D215245F800BD05D6 /* TransactionAdminFixtureTests.swift */; };
+		03F8275221525F1E00BD05D6 /* TransactionCreateParams+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F8275121525F1E00BD05D6 /* TransactionCreateParams+Admin.swift */; };
 		0722AF18088B1D5B0C533D3A /* Pods_OmiseGO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F3D88392040FB15FD17E51 /* Pods_OmiseGO.framework */; };
 		9AA7A03093BE5106A618E627 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA7D150759B05A9FDA9B003F /* Pods_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -379,6 +380,7 @@
 		03F827492150FA6C00BD05D6 /* AccountAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountAdminFixtureTests.swift; sourceTree = "<group>"; };
 		03F8274B21523FCC00BD05D6 /* Transaction+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transaction+Admin.swift"; sourceTree = "<group>"; };
 		03F8274D215245F800BD05D6 /* TransactionAdminFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionAdminFixtureTests.swift; sourceTree = "<group>"; };
+		03F8275121525F1E00BD05D6 /* TransactionCreateParams+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransactionCreateParams+Admin.swift"; sourceTree = "<group>"; };
 		16499E8AC99F7FCEE0A0FC0E /* Pods-OmiseGO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.release.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.release.xcconfig"; sourceTree = "<group>"; };
 		47235654A4C773217A4C91D9 /* Pods-OmiseGO.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OmiseGO.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OmiseGO/Pods-OmiseGO.debug.xcconfig"; sourceTree = "<group>"; };
 		D2F65698E210E4D7AEBCE81C /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -648,6 +650,7 @@
 				034F1515214F6617002BB513 /* Wallet+Admin.swift */,
 				03F827472150F45E00BD05D6 /* Account+Admin.swift */,
 				03F8274B21523FCC00BD05D6 /* Transaction+Admin.swift */,
+				03F8275121525F1E00BD05D6 /* TransactionCreateParams+Admin.swift */,
 				034F1517214F6713002BB513 /* WalletGetParams.swift */,
 				034F151F214F8708002BB513 /* WalletListForUserParams.swift */,
 				03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */,
@@ -1117,6 +1120,7 @@
 				0379E7F221184BC900E65D4F /* TransactionRequest.swift in Sources */,
 				0379E7E921184BC900E65D4F /* SocketEvent.swift in Sources */,
 				0379E7EA21184BC900E65D4F /* SocketPayload.swift in Sources */,
+				03F8275221525F1E00BD05D6 /* TransactionCreateParams+Admin.swift in Sources */,
 				03E565B3211AC87500BC9124 /* SocketClient+Client.swift in Sources */,
 				0379E7F721184BC900E65D4F /* TransactionParams.swift in Sources */,
 				0379E80621184BC900E65D4F /* Account.swift in Sources */,

--- a/Source/Admin/API/APIAdminEndpoint.swift
+++ b/Source/Admin/API/APIAdminEndpoint.swift
@@ -15,6 +15,7 @@ enum APIAdminEndpoint: APIEndpoint {
     case getWalletsForAccount(params: WalletListForAccountParams)
     case getAccounts(params: PaginatedListParams<Account>)
     case getTransactions(params: PaginatedListParams<Transaction>)
+    case createTransaction(params: TransactionCreateParams)
 
     var path: String {
         switch self {
@@ -32,6 +33,8 @@ enum APIAdminEndpoint: APIEndpoint {
             return "/account.all"
         case .getTransactions:
             return "/transaction.all"
+        case .createTransaction:
+            return "/transaction.create"
         }
     }
 
@@ -48,6 +51,8 @@ enum APIAdminEndpoint: APIEndpoint {
         case let .getAccounts(parameters):
             return .requestParameters(parameters: parameters)
         case let .getTransactions(parameters):
+            return .requestParameters(parameters: parameters)
+        case let .createTransaction(parameters):
             return .requestParameters(parameters: parameters)
         default:
             return .requestPlain

--- a/Source/Admin/Models/Transaction+Admin.swift
+++ b/Source/Admin/Models/Transaction+Admin.swift
@@ -8,6 +8,21 @@
 
 extension Transaction {
     @discardableResult
+    /// Create a new transaction
+    ///
+    /// - Parameters:
+    ///   - client: An API client.
+    ///             This client need to be initialized with a ClientConfiguration struct before being used.
+    ///   - params: The TransactionSendParams object to customize the transaction
+    ///   - callback: The closure called when the request is completed
+    /// - Returns: An optional cancellable request.
+    public static func create(using client: HTTPAdminAPI,
+                              params: TransactionCreateParams,
+                              callback: @escaping Transaction.RetrieveRequestCallback) -> Transaction.RetrieveRequest? {
+        return self.retrieve(using: client, endpoint: APIAdminEndpoint.createTransaction(params: params), callback: callback)
+    }
+
+    @discardableResult
     /// Get a paginated list of transactions
     ///
     /// - Parameters:

--- a/Source/Admin/Models/TransactionCreateParams+Admin.swift
+++ b/Source/Admin/Models/TransactionCreateParams+Admin.swift
@@ -1,0 +1,51 @@
+//
+//  TransactionCreateParams+Admin.swift
+//  OmiseGO
+//
+//  Created by Mederic Petit on 19/9/18.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import BigInt
+
+extension TransactionCreateParams {
+    public init(fromAddress: String?,
+                toAddress: String?,
+                amount: BigInt?,
+                fromAmount: BigInt?,
+                toAmount: BigInt?,
+                fromTokenId: String?,
+                toTokenId: String?,
+                tokenId: String?,
+                fromAccountId: String?,
+                toAccountId: String?,
+                fromProviderUserId: String?,
+                toProviderUserId: String?,
+                fromUserId: String?,
+                toUserId: String?,
+                idempotencyToken: String,
+                exchangeAccountId: String?,
+                exchangeAddress: String?,
+                metadata: [String: Any],
+                encryptedMetadata: [String: Any]) {
+        self.fromAddress = fromAddress
+        self.toAddress = toAddress
+        self.amount = amount
+        self.fromAmount = fromAmount
+        self.toAmount = toAmount
+        self.fromTokenId = fromTokenId
+        self.toTokenId = toTokenId
+        self.tokenId = tokenId
+        self.fromAccountId = fromAccountId
+        self.toAccountId = toAccountId
+        self.fromProviderUserId = fromProviderUserId
+        self.toProviderUserId = toProviderUserId
+        self.fromUserId = fromUserId
+        self.toUserId = toUserId
+        self.idempotencyToken = idempotencyToken
+        self.metadata = metadata
+        self.encryptedMetadata = encryptedMetadata
+        self.exchangeAddress = exchangeAddress
+        self.exchangeAccountId = exchangeAccountId
+    }
+}

--- a/Source/Client/Models/Transaction+Client.swift
+++ b/Source/Client/Models/Transaction+Client.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
 //
 
-extension Transaction: Retrievable {
+extension Transaction {
     @discardableResult
     /// Create a new transaction
     ///
@@ -21,9 +21,7 @@ extension Transaction: Retrievable {
                               callback: @escaping Transaction.RetrieveRequestCallback) -> Transaction.RetrieveRequest? {
         return self.retrieve(using: client, endpoint: APIClientEndpoint.createTransaction(params: params), callback: callback)
     }
-}
 
-extension Transaction {
     @discardableResult
     /// Get a paginated list of transaction for the current user
     ///

--- a/Source/Core/Helpers/Tool.swift
+++ b/Source/Core/Helpers/Tool.swift
@@ -22,6 +22,9 @@ func deserializeData<ObjectType: Decodable>(_ data: Data) throws -> ObjectType {
 
 func serialize<ObjectType: Encodable>(_ object: ObjectType) throws -> Data {
     let jsonEncoder = JSONEncoder()
+    if #available(iOS 11.0, *) {
+        jsonEncoder.outputFormatting = .sortedKeys
+    }
     jsonEncoder.dateEncodingStrategy = .custom({ try dateEncodingStrategy(date: $0, encoder: $1) })
     return try jsonEncoder.encode(object)
 }

--- a/Source/Core/Models/Transaction.swift
+++ b/Source/Core/Models/Transaction.swift
@@ -93,6 +93,8 @@ extension Transaction: Sortable {
 
 extension Transaction: PaginatedListable {}
 
+extension Transaction: Retrievable {}
+
 extension Transaction: Hashable {
     public var hashValue: Int {
         return self.id.hashValue

--- a/Source/Core/Models/TransactionParams.swift
+++ b/Source/Core/Models/TransactionParams.swift
@@ -11,44 +11,43 @@ import BigInt
 /// Represents a structure used to create a transaction
 public struct TransactionCreateParams {
     /// The address from which to take the tokens (which must belong to the user).
-    /// If not specified, the user's primary balance will be used.
     public let fromAddress: String?
     /// The address where to send the tokens
     public let toAddress: String?
+    /// The provider user id where to take the token from
+    public let fromProviderUserId: String?
     /// The provider user id where to send the token
     public let toProviderUserId: String?
+    /// The user id where to take the token from
+    public let fromUserId: String?
+    /// The user id where to send the token
+    public let toUserId: String?
+    /// The account id where to take the token from
+    public let fromAccountId: String?
     /// The account id where to send the tokens
     public let toAccountId: String?
     /// The amount of token to send (down to subunit to unit)
-    public let amount: BigInt
+    public let amount: BigInt?
+    /// The amount of token to send (down to subunit to unit)
+    public let fromAmount: BigInt?
+    /// The amount of token expected to be received (down to subunit to unit)
+    public let toAmount: BigInt?
+    /// The id of the token that will be used to send or receive the funds
+    public let tokenId: String?
     /// The id of the token that will be used to send the funds
-    public let tokenId: String
+    public let fromTokenId: String?
+    /// The id of the token that will be used to receive the funds
+    public let toTokenId: String?
     /// The idempotency token of the request
     public let idempotencyToken: String
+    /// The account id to use for exchanging the tokens
+    public let exchangeAccountId: String?
+    /// The address to use for exchanging the tokens
+    public let exchangeAddress: String?
     /// Additional metadata for the transaction
     public let metadata: [String: Any]
     /// Additional encrypted metadata for the transaction
     public let encryptedMetadata: [String: Any]
-
-    private init(fromAddress: String?,
-                 amount: BigInt,
-                 tokenId: String,
-                 toAddress: String?,
-                 toAccountId: String?,
-                 toProviderUserId: String?,
-                 idempotencyToken: String,
-                 metadata: [String: Any],
-                 encryptedMetadata: [String: Any]) {
-        self.fromAddress = fromAddress
-        self.amount = amount
-        self.tokenId = tokenId
-        self.toAddress = toAddress
-        self.toAccountId = toAccountId
-        self.toProviderUserId = toProviderUserId
-        self.idempotencyToken = idempotencyToken
-        self.metadata = metadata
-        self.encryptedMetadata = encryptedMetadata
-    }
 
     public init(fromAddress: String? = nil,
                 toAddress: String,
@@ -57,15 +56,25 @@ public struct TransactionCreateParams {
                 idempotencyToken: String,
                 metadata: [String: Any] = [:],
                 encryptedMetadata: [String: Any] = [:]) {
-        self.init(fromAddress: fromAddress,
-                  amount: amount,
-                  tokenId: tokenId,
-                  toAddress: toAddress,
-                  toAccountId: nil,
-                  toProviderUserId: nil,
-                  idempotencyToken: idempotencyToken,
-                  metadata: metadata,
-                  encryptedMetadata: encryptedMetadata)
+        self.fromAddress = fromAddress
+        self.toAddress = toAddress
+        self.amount = amount
+        self.fromAmount = nil
+        self.toAmount = nil
+        self.fromTokenId = nil
+        self.toTokenId = nil
+        self.tokenId = tokenId
+        self.fromAccountId = nil
+        self.toAccountId = nil
+        self.fromProviderUserId = nil
+        self.toProviderUserId = nil
+        self.fromUserId = nil
+        self.toUserId = nil
+        self.idempotencyToken = idempotencyToken
+        self.metadata = metadata
+        self.encryptedMetadata = encryptedMetadata
+        self.exchangeAddress = nil
+        self.exchangeAccountId = nil
     }
 
     public init(fromAddress: String? = nil,
@@ -76,15 +85,25 @@ public struct TransactionCreateParams {
                 idempotencyToken: String,
                 metadata: [String: Any] = [:],
                 encryptedMetadata: [String: Any] = [:]) {
-        self.init(fromAddress: fromAddress,
-                  amount: amount,
-                  tokenId: tokenId,
-                  toAddress: toAddress,
-                  toAccountId: toAccountId,
-                  toProviderUserId: nil,
-                  idempotencyToken: idempotencyToken,
-                  metadata: metadata,
-                  encryptedMetadata: encryptedMetadata)
+        self.fromAddress = fromAddress
+        self.toAddress = toAddress
+        self.amount = amount
+        self.fromAmount = nil
+        self.toAmount = nil
+        self.fromTokenId = nil
+        self.toTokenId = nil
+        self.tokenId = tokenId
+        self.fromAccountId = nil
+        self.toAccountId = toAccountId
+        self.fromProviderUserId = nil
+        self.toProviderUserId = nil
+        self.fromUserId = nil
+        self.toUserId = nil
+        self.idempotencyToken = idempotencyToken
+        self.metadata = metadata
+        self.encryptedMetadata = encryptedMetadata
+        self.exchangeAddress = nil
+        self.exchangeAccountId = nil
     }
 
     public init(fromAddress: String? = nil,
@@ -95,15 +114,25 @@ public struct TransactionCreateParams {
                 idempotencyToken: String,
                 metadata: [String: Any] = [:],
                 encryptedMetadata: [String: Any] = [:]) {
-        self.init(fromAddress: fromAddress,
-                  amount: amount,
-                  tokenId: tokenId,
-                  toAddress: toAddress,
-                  toAccountId: nil,
-                  toProviderUserId: toProviderUserId,
-                  idempotencyToken: idempotencyToken,
-                  metadata: metadata,
-                  encryptedMetadata: encryptedMetadata)
+        self.fromAddress = fromAddress
+        self.toAddress = toAddress
+        self.amount = amount
+        self.fromAmount = nil
+        self.toAmount = nil
+        self.fromTokenId = nil
+        self.toTokenId = nil
+        self.tokenId = tokenId
+        self.fromAccountId = nil
+        self.toAccountId = nil
+        self.fromProviderUserId = nil
+        self.toProviderUserId = toProviderUserId
+        self.fromUserId = nil
+        self.toUserId = nil
+        self.idempotencyToken = idempotencyToken
+        self.metadata = metadata
+        self.encryptedMetadata = encryptedMetadata
+        self.exchangeAddress = nil
+        self.exchangeAccountId = nil
     }
 }
 
@@ -111,24 +140,44 @@ extension TransactionCreateParams: APIParameters {
     private enum CodingKeys: String, CodingKey {
         case fromAddress = "from_address"
         case toAddress = "to_address"
-        case toAccountId = "to_account_id"
+        case fromProviderUserId = "from_provider_user_id"
         case toProviderUserId = "to_provider_user_id"
+        case fromUserId = "from_user_id"
+        case toUserId = "to_user_id"
+        case fromAccountId = "from_account_id"
+        case toAccountId = "to_account_id"
         case amount
+        case fromAmount = "from_amount"
+        case toAmount = "to_amount"
         case tokenId = "token_id"
+        case fromTokenId = "from_token_id"
+        case toTokenId = "to_token_id"
         case idempotencyToken = "idempotency_token"
+        case exchangeAccountId = "exchange_account_id"
+        case exchangeAddress = "exchange_address"
         case metadata
         case encryptedMetadata = "encrypted_metadata"
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(fromAddress, forKey: .fromAddress)
+        try container.encodeIfPresent(fromAddress, forKey: .fromAddress)
         try container.encodeIfPresent(toAddress, forKey: .toAddress)
-        try container.encodeIfPresent(toAccountId, forKey: .toAccountId)
+        try container.encodeIfPresent(fromProviderUserId, forKey: .fromProviderUserId)
         try container.encodeIfPresent(toProviderUserId, forKey: .toProviderUserId)
-        try container.encode(amount, forKey: .amount)
-        try container.encode(tokenId, forKey: .tokenId)
+        try container.encodeIfPresent(fromUserId, forKey: .fromUserId)
+        try container.encodeIfPresent(toUserId, forKey: .toUserId)
+        try container.encodeIfPresent(fromAccountId, forKey: .fromAccountId)
+        try container.encodeIfPresent(toAccountId, forKey: .toAccountId)
+        try container.encodeIfPresent(amount, forKey: .amount)
+        try container.encodeIfPresent(fromAmount, forKey: .fromAmount)
+        try container.encodeIfPresent(toAmount, forKey: .toAmount)
+        try container.encodeIfPresent(tokenId, forKey: .tokenId)
+        try container.encodeIfPresent(fromTokenId, forKey: .fromTokenId)
+        try container.encodeIfPresent(toTokenId, forKey: .toTokenId)
         try container.encode(idempotencyToken, forKey: .idempotencyToken)
+        try container.encodeIfPresent(exchangeAccountId, forKey: .exchangeAccountId)
+        try container.encodeIfPresent(exchangeAddress, forKey: .exchangeAddress)
         try container.encode(metadata, forKey: .metadata)
         try container.encode(encryptedMetadata, forKey: .encryptedMetadata)
     }

--- a/Source/Core/Models/Wallet.swift
+++ b/Source/Core/Models/Wallet.swift
@@ -48,15 +48,20 @@ extension Wallet: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         address = try container.decode(String.self, forKey: .address)
-        balances = try container.decode([Balance].self, forKey: .balances)
-        name = try container.decode(String.self, forKey: .name)
-        identifier = try container.decode(String.self, forKey: .identifier)
-        userId = try container.decodeIfPresent(String.self, forKey: .userId)
-        user = try container.decodeIfPresent(User.self, forKey: .user)
-        accountId = try container.decodeIfPresent(String.self, forKey: .accountId)
-        account = try container.decodeIfPresent(Account.self, forKey: .account)
-        metadata = try container.decode([String: Any].self, forKey: .metadata)
-        encryptedMetadata = try container.decode([String: Any].self, forKey: .encryptedMetadata)
+        let decodedBalances = try container.decodeIfPresent([Balance].self, forKey: .balances)
+        if let balances = decodedBalances {
+            self.balances = balances
+        } else {
+            self.balances = []
+        }
+        self.name = try container.decode(String.self, forKey: .name)
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.userId = try container.decodeIfPresent(String.self, forKey: .userId)
+        self.user = try container.decodeIfPresent(User.self, forKey: .user)
+        self.accountId = try container.decodeIfPresent(String.self, forKey: .accountId)
+        self.account = try container.decodeIfPresent(Account.self, forKey: .account)
+        self.metadata = try container.decode([String: Any].self, forKey: .metadata)
+        self.encryptedMetadata = try container.decode([String: Any].self, forKey: .encryptedMetadata)
     }
 }
 

--- a/Tests/Admin/FixtureTests/TransactionAdminFixtureTests.swift
+++ b/Tests/Admin/FixtureTests/TransactionAdminFixtureTests.swift
@@ -3,7 +3,7 @@
 //  Tests
 //
 //  Created by Mederic Petit on 19/9/18.
-//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//  Copyright © 2017-2018 Omise Go Pte. Ltd. All rights reserved.
 //
 
 import OmiseGO
@@ -28,6 +28,47 @@ class TransactionAdminFixtureTests: FixtureAdminTestCase {
                     XCTFail("\(error)")
                 }
             }
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+
+    func testCreateTransaction() {
+        let expectation = self.expectation(description: "Create a transaction")
+        let params = TransactionCreateParams(fromAddress: "dqhg022708121978",
+                                             toAddress: "iciu825817955943",
+                                             amount: nil,
+                                             fromAmount: nil,
+                                             toAmount: 200,
+                                             fromTokenId: "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+                                             toTokenId: "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+                                             tokenId: nil,
+                                             fromAccountId: "acc_01cqwwqz8zpsgta8rsm244w8rr",
+                                             toAccountId: "acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
+                                             fromProviderUserId: nil,
+                                             toProviderUserId: nil,
+                                             fromUserId: nil,
+                                             toUserId: nil,
+                                             idempotencyToken: "82492734829374",
+                                             exchangeAccountId: "acc_01cqwwqz8zpsgta8rsm244w8rr",
+                                             exchangeAddress: "dqhg022708121978",
+                                             metadata: ["a_key": "a_value"],
+                                             encryptedMetadata: ["a_key": "a_value"])
+        let request = Transaction.create(using: self.testClient, params: params) { (result) in
+            defer { expectation.fulfill() }
+            switch result {
+            case let .success(data: transaction):
+                XCTAssertEqual(transaction.from.account!.id, "acc_01cqwwqz8zpsgta8rsm244w8rr")
+                XCTAssertEqual(transaction.to.account!.id, "acc_01cqx8qt9hgnbz1vkwhm5ymkbn")
+                XCTAssertEqual(transaction.from.address, "dqhg022708121978")
+                XCTAssertEqual(transaction.to.address, "iciu825817955943")
+                XCTAssertEqual(transaction.from.token.id, "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq")
+                XCTAssertEqual(transaction.to.token.id, "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48")
+                XCTAssertEqual(transaction.exchange.exchangeAccountId!, "acc_01cqwwqz8zpsgta8rsm244w8rr")
+                XCTAssertEqual(transaction.exchange.exchangeWalletAddress!, "dqhg022708121978")
+            case let .fail(error: error):
+                XCTFail("\(error)")
+            }
+        }
         XCTAssertNotNil(request)
         waitForExpectations(timeout: 15.0, handler: nil)
     }

--- a/Tests/Admin/FixtureTests/admin_fixtures/api/transaction.create.json
+++ b/Tests/Admin/FixtureTests/admin_fixtures/api/transaction.create.json
@@ -1,0 +1,217 @@
+{
+  "version": "1",
+  "success": true,
+  "data": {
+    "updated_at": "2018-09-24T05:33:57.952836Z",
+    "to": {
+      "user_id": null,
+      "user": null,
+      "token_id": "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+      "token": {
+        "updated_at": "2018-09-21T05:15:19.986923Z",
+        "symbol": "NTN",
+        "subunit_to_unit": 100,
+        "object": "token",
+        "name": "Neutrino",
+        "metadata": {},
+        "id": "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+        "encrypted_metadata": {},
+        "enabled": true,
+        "created_at": "2018-09-21T05:15:19.986916Z"
+      },
+      "object": "transaction_source",
+      "amount": 200,
+      "address": "iciu825817955943",
+      "account_id": "acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
+      "account": {
+        "updated_at": "2018-09-21T05:13:17.873565Z",
+        "socket_topic": "account:acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
+        "parent_id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+        "object": "account",
+        "name": "Singapore",
+        "metadata": {},
+        "master": false,
+        "id": "acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
+        "encrypted_metadata": {},
+        "description": "Singapore",
+        "created_at": "2018-09-21T05:13:17.873558Z",
+        "category_ids": [],
+        "categories": {
+          "object": "list",
+          "data": []
+        },
+        "avatar": {
+          "thumb": null,
+          "small": null,
+          "original": null,
+          "large": null
+        }
+      }
+    },
+    "status": "confirmed",
+    "object": "transaction",
+    "metadata": {
+      "a_key": "a_value"
+    },
+    "idempotency_token": "82492734829374",
+    "id": "txn_01cr513t95d061rcgv2pr90awc",
+    "from": {
+      "user_id": null,
+      "user": null,
+      "token_id": "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+      "token": {
+        "updated_at": "2018-09-21T05:22:21.655506Z",
+        "symbol": "NT2",
+        "subunit_to_unit": 100,
+        "object": "token",
+        "name": "Neutrino 2",
+        "metadata": {},
+        "id": "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+        "encrypted_metadata": {},
+        "enabled": true,
+        "created_at": "2018-09-21T05:22:21.655498Z"
+      },
+      "object": "transaction_source",
+      "amount": 400,
+      "address": "dqhg022708121978",
+      "account_id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+      "account": {
+        "updated_at": "2018-09-21T01:44:04.571154Z",
+        "socket_topic": "account:acc_01cqwwqz8zpsgta8rsm244w8rr",
+        "parent_id": null,
+        "object": "account",
+        "name": "Master Account",
+        "metadata": {},
+        "master": true,
+        "id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+        "encrypted_metadata": {},
+        "description": "Master Account",
+        "created_at": "2018-09-21T01:43:40.067136Z",
+        "category_ids": [],
+        "categories": {
+          "object": "list",
+          "data": []
+        },
+        "avatar": {
+          "thumb": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/thumb.png?v=63704713444",
+          "small": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/small.png?v=63704713444",
+          "original": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/original.jpg?v=63704713444",
+          "large": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/large.png?v=63704713444"
+        }
+      }
+    },
+    "exchange": {
+      "rate": 0.5,
+      "object": "exchange",
+      "exchange_wallet_address": "dqhg022708121978",
+      "exchange_wallet": {
+        "user_id": null,
+        "user": null,
+        "updated_at": "2018-09-21T01:43:40.088282Z",
+        "socket_topic": "wallet:dqhg022708121978",
+        "object": "wallet",
+        "name": "primary",
+        "metadata": {},
+        "identifier": "primary",
+        "encrypted_metadata": {},
+        "enabled": true,
+        "created_at": "2018-09-21T01:43:40.088270Z",
+        "balances": null,
+        "address": "dqhg022708121978",
+        "account_id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+        "account": {
+          "updated_at": "2018-09-21T01:44:04.571154Z",
+          "socket_topic": "account:acc_01cqwwqz8zpsgta8rsm244w8rr",
+          "parent_id": null,
+          "object": "account",
+          "name": "Master Account",
+          "metadata": {},
+          "master": true,
+          "id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+          "encrypted_metadata": {},
+          "description": "Master Account",
+          "created_at": "2018-09-21T01:43:40.067136Z",
+          "category_ids": [],
+          "categories": {
+            "object": "list",
+            "data": []
+          },
+          "avatar": {
+            "thumb": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/thumb.png?v=63704713444",
+            "small": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/small.png?v=63704713444",
+            "original": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/original.jpg?v=63704713444",
+            "large": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/large.png?v=63704713444"
+          }
+        }
+      },
+      "exchange_pair_id": "exg_01cqx98n071yw80nacskky22ra",
+      "exchange_pair": {
+        "updated_at": "2018-09-21T05:22:29.511768Z",
+        "to_token_id": "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+        "to_token": {
+          "updated_at": "2018-09-21T05:15:19.986923Z",
+          "symbol": "NTN",
+          "subunit_to_unit": 100,
+          "object": "token",
+          "name": "Neutrino",
+          "metadata": {},
+          "id": "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+          "encrypted_metadata": {},
+          "enabled": true,
+          "created_at": "2018-09-21T05:15:19.986916Z"
+        },
+        "rate": 0.5,
+        "object": "exchange_pair",
+        "name": "NT2/NTN",
+        "id": "exg_01cqx98n071yw80nacskky22ra",
+        "from_token_id": "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+        "from_token": {
+          "updated_at": "2018-09-21T05:22:21.655506Z",
+          "symbol": "NT2",
+          "subunit_to_unit": 100,
+          "object": "token",
+          "name": "Neutrino 2",
+          "metadata": {},
+          "id": "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+          "encrypted_metadata": {},
+          "enabled": true,
+          "created_at": "2018-09-21T05:22:21.655498Z"
+        },
+        "deleted_at": null,
+        "created_at": "2018-09-21T05:22:29.511762Z"
+      },
+      "exchange_account_id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+      "exchange_account": {
+        "updated_at": "2018-09-21T01:44:04.571154Z",
+        "socket_topic": "account:acc_01cqwwqz8zpsgta8rsm244w8rr",
+        "parent_id": null,
+        "object": "account",
+        "name": "Master Account",
+        "metadata": {},
+        "master": true,
+        "id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+        "encrypted_metadata": {},
+        "description": "Master Account",
+        "created_at": "2018-09-21T01:43:40.067136Z",
+        "category_ids": [],
+        "categories": {
+          "object": "list",
+          "data": []
+        },
+        "avatar": {
+          "thumb": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/thumb.png?v=63704713444",
+          "small": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/small.png?v=63704713444",
+          "original": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/original.jpg?v=63704713444",
+          "large": "http://localhost:4000/public/uploads/dev/account/avatars/acc_01cqwwqz8zpsgta8rsm244w8rr/large.png?v=63704713444"
+        }
+      },
+      "calculated_at": "2018-09-24T05:33:57.923439Z"
+    },
+    "error_description": null,
+    "error_code": null,
+    "encrypted_metadata": {
+      "a_key": "a_value"
+    },
+    "created_at": "2018-09-24T05:33:57.925639Z"
+  }
+}

--- a/Tests/Core/CodingTests/EncodeTests.swift
+++ b/Tests/Core/CodingTests/EncodeTests.swift
@@ -23,6 +23,9 @@ class EncodeTests: XCTestCase {
         super.setUp()
         let jsonEncoder = JSONEncoder()
         jsonEncoder.dateEncodingStrategy = .custom({ try dateEncodingStrategy(date: $0, encoder: $1) })
+        if #available(iOS 11.0, *) {
+            jsonEncoder.outputFormatting = .sortedKeys
+        }
         self.encoder = jsonEncoder
     }
 
@@ -57,18 +60,18 @@ class EncodeTests: XCTestCase {
         {
             "metadata":{
                 "a_bool":true,
-                "an_integer":1,
-                "an_array":["value_1","value_2"],
                 "a_double":12.34,
+                "a_string":"some_string",
+                "an_array":["value_1","value_2"],
+                "an_integer":1,
                 "an_object":{
+                    "a_key":"a_value",
                     "a_nested_object":{
                         "a_nested_key":"a_nested_value"
                     },
-                    "a_key":"a_value",
-                    "a_nil_value": null},
-                "a_string":"some_string"
+                    "a_nil_value": null
+                }
             },
-            "optional_metadata_array":["a_value"],
             "metadata_array":[
                 "value_1",
                 123,
@@ -79,7 +82,8 @@ class EncodeTests: XCTestCase {
             ],
             "optional_metadata":{
                 "a_key":"a_value"
-            }
+            },
+            "optional_metadata_array":["a_value"]
         }
         """.uglifiedEncodedString())
     }
@@ -98,8 +102,8 @@ class EncodeTests: XCTestCase {
         let jsonString = String(data: encodedData, encoding: .utf8)!
         XCTAssertEqual(jsonString, """
             {
-                "metadata_array":[],
-                "metadata":{}
+                "metadata":{},
+                "metadata_array":[]
             }
         """.uglifiedEncodedString())
     }
@@ -121,7 +125,9 @@ class EncodeTests: XCTestCase {
         do {
             let encodedData = try self.encoder.encode(encodable)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
-                {"value": 922337203685400}
+                {
+                    "value": 922337203685400
+                }
             """.uglifiedEncodedString())
         } catch _ {
             XCTFail("Should not raise an error")
@@ -133,7 +139,9 @@ class EncodeTests: XCTestCase {
         do {
             let encodedData = try self.encoder.encode(encodable)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
-                {"value": 99999999999999999999999999999999999998}
+                {
+                    "value": 99999999999999999999999999999999999998
+                }
             """.uglifiedEncodedString())
         } catch _ {
             XCTFail("Should not raise an error")
@@ -216,19 +224,19 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "require_confirmation":true,
-                    "consumption_lifetime":1000,
-                    "allow_amount_override":true,
-                    "encrypted_metadata":{},
-                    "amount":null,
-                    "metadata":{},
-                    "token_id":"BTC:861020af-17b6-49ee-a0cb-661a4d2d1f95",
-                    "type":"receive",
-                    "max_consumptions":1,
                     "address":"3b7f1c68-e3bd-4f8f-9916-4af19be95d00",
+                    "allow_amount_override":true,
+                    "amount":null,
+                    "consumption_lifetime":1000,
                     "correlation_id":"31009545-db10-4287-82f4-afb46d9741d8",
+                    "encrypted_metadata":{},
+                    "expiration_date":"1970-01-01T00:00:00Z",
+                    "max_consumptions":1,
                     "max_consumptions_per_user":5,
-                    "expiration_date":"1970-01-01T00:00:00Z"
+                    "metadata":{},
+                    "require_confirmation":true,
+                    "token_id":"BTC:861020af-17b6-49ee-a0cb-661a4d2d1f95",
+                    "type":"receive"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -255,19 +263,19 @@ class EncodeTests: XCTestCase {
             let encodedData = try self.encoder.encode(transactionRequestParams)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "require_confirmation":true,
-                    "consumption_lifetime":1000,
-                    "allow_amount_override":false,
-                    "encrypted_metadata":{},
-                    "amount":1337,
-                    "metadata":{},
-                    "token_id":"BTC:861020af-17b6-49ee-a0cb-661a4d2d1f95",
-                    "type":"receive",
-                    "max_consumptions":1,
                     "address":"3b7f1c68-e3bd-4f8f-9916-4af19be95d00",
+                    "allow_amount_override":false,
+                    "amount":1337,
+                    "consumption_lifetime":1000,
                     "correlation_id":"31009545-db10-4287-82f4-afb46d9741d8",
+                    "encrypted_metadata":{},
+                    "expiration_date":"1970-01-01T00:00:00Z",
+                    "max_consumptions":1,
                     "max_consumptions_per_user":5,
-                    "expiration_date":"1970-01-01T00:00:00Z"
+                    "metadata":{},
+                    "require_confirmation":true,
+                    "token_id":"BTC:861020af-17b6-49ee-a0cb-661a4d2d1f95",
+                    "type":"receive"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -284,7 +292,9 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData,
                                   encoding: .utf8)!, """
-                                                                                            {"formatted_id":"|0a8a4a98-794b-419e-b92d-514e83657e75"}
+                            {
+                                "formatted_id":"|0a8a4a98-794b-419e-b92d-514e83657e75"
+                            }
             """.uglifiedEncodedString())
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
@@ -331,12 +341,12 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
+                    "address":"456",
                     "amount":null,
                     "correlation_id":"321",
-                    "formatted_transaction_request_id":"|0a8a4a98-794b-419e-b92d-514e83657e75",
-                    "address":"456",
-                    "idempotency_token":"123",
                     "encrypted_metadata":{},
+                    "formatted_transaction_request_id":"|0a8a4a98-794b-419e-b92d-514e83657e75",
+                    "idempotency_token":"123",
                     "metadata":{}
                 }
             """.uglifiedEncodedString())
@@ -358,11 +368,11 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "search_term":"test",
+                    "page":1,
                     "per_page":20,
-                    "sort_dir":"asc",
+                    "search_term":"test",
                     "sort_by":"a_sortable_attribute",
-                    "page":1
+                    "sort_dir":"asc"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -381,11 +391,11 @@ class EncodeTests: XCTestCase {
             let encodedData = try self.encoder.encode(paginationParams)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "search_terms":{"a_searchable_attribute":"test"},
+                    "page":1,
                     "per_page":20,
-                    "sort_dir":"asc",
+                    "search_terms":{"a_searchable_attribute":"test"},
                     "sort_by":"a_sortable_attribute",
-                    "page":1
+                    "sort_dir":"asc"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -403,10 +413,10 @@ class EncodeTests: XCTestCase {
             let encodedData = try self.encoder.encode(paginationParams)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
+                    "page":1,
                     "per_page":20,
-                    "sort_dir":"asc",
                     "sort_by":"a_sortable_attribute",
-                    "page":1
+                    "sort_dir":"asc"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -427,12 +437,12 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
+                    "address":"123",
                     "page":1,
-                    "search_term":"test",
                     "per_page":20,
-                    "sort_dir":"desc",
+                    "search_term":"test",
                     "sort_by":"created_at",
-                    "address":"123"
+                    "sort_dir":"desc"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -449,9 +459,9 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
                     "data":{"a_key":"a_value"},
-                    "topic":"a_topic",
                     "event":"phx_join",
-                    "ref":"1"
+                    "ref":"1",
+                    "topic":"a_topic"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -467,7 +477,9 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData,
                                   encoding: .utf8)!, """
-                                                                                            {"id":"0a8a4a98-794b-419e-b92d-514e83657e75"}
+                            {
+                                "id":"0a8a4a98-794b-419e-b92d-514e83657e75"
+                            }
             """.uglifiedEncodedString())
         } catch let thrownError {
             XCTFail(thrownError.localizedDescription)
@@ -490,11 +502,11 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
                     "amount":1337,
-                    "to_address":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
-                    "idempotency_token":"123",
                     "encrypted_metadata":{"a_key":"a_value"},
-                    "metadata":{"a_key":"a_value"},
                     "from_address":"86e274e2-c8dc-46cf-ac4e-d8b26b5aada3",
+                    "idempotency_token":"123",
+                    "metadata":{"a_key":"a_value"},
+                    "to_address":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
                     "token_id":"BTC:06b8ebc3-237b-4631-a1c7-2ecbd1d623c6"
                 }
             """.uglifiedEncodedString())
@@ -519,11 +531,11 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
                     "amount":1337,
-                    "to_account_id":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
-                    "idempotency_token":"123",
                     "encrypted_metadata":{"a_key":"a_value"},
-                    "metadata":{"a_key":"a_value"},
                     "from_address":"86e274e2-c8dc-46cf-ac4e-d8b26b5aada3",
+                    "idempotency_token":"123",
+                    "metadata":{"a_key":"a_value"},
+                    "to_account_id":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
                     "token_id":"BTC:06b8ebc3-237b-4631-a1c7-2ecbd1d623c6"
                 }
             """.uglifiedEncodedString())
@@ -548,12 +560,64 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
                     "amount":1337,
-                    "to_provider_user_id":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
-                    "idempotency_token":"123",
                     "encrypted_metadata":{"a_key":"a_value"},
-                    "metadata":{"a_key":"a_value"},
                     "from_address":"86e274e2-c8dc-46cf-ac4e-d8b26b5aada3",
+                    "idempotency_token":"123",
+                    "metadata":{"a_key":"a_value"},
+                    "to_provider_user_id":"2bd75f2f-6e83-4727-a8b5-2849a9715064",
                     "token_id":"BTC:06b8ebc3-237b-4631-a1c7-2ecbd1d623c6"
+                }
+            """.uglifiedEncodedString())
+        } catch let thrownError {
+            XCTFail(thrownError.localizedDescription)
+        }
+    }
+
+    func testTransactionParamsEncodingFull() {
+        do {
+            let transactionParams = TransactionCreateParams(fromAddress: "dqhg022708121978",
+                                                            toAddress: "qrxe701832114087",
+                                                            amount: 1,
+                                                            fromAmount: 1,
+                                                            toAmount: 2,
+                                                            fromTokenId: "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+                                                            toTokenId: "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+                                                            tokenId: "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+                                                            fromAccountId: "acc_01cqwwqz8zpsgta8rsm244w8rr",
+                                                            toAccountId: "acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
+                                                            fromProviderUserId: "123",
+                                                            toProviderUserId: "321",
+                                                            fromUserId: "usr_01cqx93p4jh939xbq5k71evswe",
+                                                            toUserId: "usr_01qqx93p4jh939xbq5k71evswe",
+                                                            idempotencyToken: "1234",
+                                                            exchangeAccountId: "acc_01cqwwqz8zpsgta8rsm244w8rr",
+                                                            exchangeAddress: "dqhg022708121978",
+                                                            metadata: ["a_key": "a_value"],
+                                                            encryptedMetadata: ["a_key": "a_value"])
+            let encodedData = try self.encoder.encode(transactionParams)
+            let encodedPayload = try! transactionParams.encodedPayload()
+            XCTAssertEqual(encodedData, encodedPayload)
+            XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
+                {
+                    "amount":1,
+                    "encrypted_metadata":{"a_key":"a_value"},
+                    "exchange_account_id": "acc_01cqwwqz8zpsgta8rsm244w8rr",
+                    "exchange_address": "dqhg022708121978",
+                    "from_account_id":"acc_01cqwwqz8zpsgta8rsm244w8rr",
+                    "from_address":"dqhg022708121978",
+                    "from_amount":1,
+                    "from_provider_user_id":"123",
+                    "from_token_id":"tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
+                    "from_user_id":"usr_01cqx93p4jh939xbq5k71evswe",
+                    "idempotency_token":"1234",
+                    "metadata":{"a_key":"a_value"},
+                    "to_account_id":"acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
+                    "to_address":"qrxe701832114087",
+                    "to_amount":2,
+                    "to_provider_user_id":"321",
+                    "to_token_id":"tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
+                    "to_user_id":"usr_01qqx93p4jh939xbq5k71evswe",
+                    "token_id":"tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -588,9 +652,9 @@ class EncodeTests: XCTestCase {
                 {
                     "email":"email@example.com",
                     "password":"password",
+                    "password_confirmation":"password",
                     "success_url":"yyy",
-                    "verification_url":"xxx",
-                    "password_confirmation":"password"
+                    "verification_url":"xxx"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -611,12 +675,12 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "search_term":"test",
-                    "per_page":20,
                     "id":"123",
-                    "sort_dir":"asc",
+                    "page":1,
+                    "per_page":20,
+                    "search_term":"test",
                     "sort_by":"address",
-                    "page":1
+                    "sort_dir":"asc"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {
@@ -638,13 +702,13 @@ class EncodeTests: XCTestCase {
             XCTAssertEqual(encodedData, encodedPayload)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
-                    "per_page":20,
-                    "page":1,
                     "id":"123",
                     "owned": true,
-                    "sort_dir":"asc",
+                    "page":1,
+                    "per_page":20,
                     "search_term":"test",
-                    "sort_by":"address"
+                    "sort_by":"address",
+                    "sort_dir":"asc"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {


### PR DESCRIPTION
Closes #82 

# Overview

This PR adds the create admin transaction API.

# Usage

```
        let params = TransactionCreateParams(fromAddress: "dqhg022708121978",
                                             toAddress: "iciu825817955943",
                                             amount: nil,
                                             fromAmount: nil,
                                             toAmount: 200,
                                             fromTokenId: "tok_NT2_01cqx98daqa6qf0pdzn3e5csjq",
                                             toTokenId: "tok_NTN_01cqx8vhhj1h9mb1mw8hj5vs48",
                                             tokenId: nil,
                                             fromAccountId: "acc_01cqwwqz8zpsgta8rsm244w8rr",
                                             toAccountId: "acc_01cqx8qt9hgnbz1vkwhm5ymkbn",
                                             fromProviderUserId: nil,
                                             toProviderUserId: nil,
                                             fromUserId: nil,
                                             toUserId: nil,
                                             idempotencyToken: "82492734829374123",
                                             exchangeAccountId: "acc_01cqwwqz8zpsgta8rsm244w8rr",
                                             exchangeAddress: "dqhg022708121978",
                                             metadata: ["a_key": "a_value"],
                                             encryptedMetadata: ["a_key": "a_value"])
        Transaction.create(using: self.apiClient, params: params) { (result) in
            switch result {
            case let .success(data: transaction):
                print(transaction)
            case let .fail(error: error): print(error)
            }
        }
```