### PR TITLE
Add [weak self] where missing from closures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: swift
 osx_image: xcode10
+cache:
+- bundler
+- cocoapods
 env:
   matrix:
     - TEST_TYPE=iOS

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ env:
     - TEST_TYPE=iOS
     - TEST_TYPE=Lint
     - TEST_TYPE=CocoaPods
-before_install:
-- |
-  if [ "$TEST_TYPE" = Lint ]; then
-    brew update
-  fi
 install:
 - |
   if [ "$TEST_TYPE" = Lint ]; then

--- a/Source/Admin/API/HTTPAdminAPI.swift
+++ b/Source/Admin/API/HTTPAdminAPI.swift
@@ -29,15 +29,17 @@ extension HTTPAdminAPI {
     public func login(withParams params: LoginParams,
                       callback: @escaping Request<AuthenticationToken>.Callback)
         -> Request<AuthenticationToken>? {
-        let request: Request<AuthenticationToken>? = self.request(toEndpoint: APIAdminEndpoint.login(params: params)) { result in
-            switch result {
-            case let .success(data: authenticationToken):
-                self.config.credentials.update(withAuthenticationToken: authenticationToken)
-                callback(.success(data: authenticationToken))
-            case let .fail(error):
-                callback(.fail(error: error))
+        let request: Request<AuthenticationToken>? =
+            self.request(toEndpoint: APIAdminEndpoint.login(params: params)) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case let .success(data: authenticationToken):
+                    self.config.credentials.update(withAuthenticationToken: authenticationToken)
+                    callback(.success(data: authenticationToken))
+                case let .fail(error):
+                    callback(.fail(error: error))
+                }
             }
-        }
         return request
     }
 
@@ -48,7 +50,8 @@ extension HTTPAdminAPI {
     @discardableResult
     public func logout(withCallback callback: @escaping Request<EmptyResponse>.Callback)
         -> Request<EmptyResponse>? {
-        let request: Request<EmptyResponse>? = self.request(toEndpoint: APIAdminEndpoint.logout) { result in
+        let request: Request<EmptyResponse>? = self.request(toEndpoint: APIAdminEndpoint.logout) { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case let .success(data: data):
                 self.config.credentials.invalidate()

--- a/Source/Core/QRCode/QRReader.swift
+++ b/Source/Core/QRCode/QRReader.swift
@@ -65,13 +65,13 @@ extension QRReader: AVCaptureMetadataOutputObjectsDelegate {
                         didOutput metadataObjects: [AVMetadataObject],
                         from _: AVCaptureConnection) {
         self.sessionQueue.async { [weak self] in
-            guard let weakSelf = self else { return }
+            guard let self = self else { return }
             guard !metadataObjects.isEmpty,
                 let metadataObject = metadataObjects[0] as? AVMetadataMachineReadableCodeObject,
                 metadataObject.type == AVMetadataObject.ObjectType.qr,
                 let decodedData = metadataObject.stringValue
             else { return }
-            weakSelf.didReadCode(decodedData)
+            self.didReadCode(decodedData)
         }
     }
 }

--- a/Source/Core/QRCode/QRScannerViewModel.swift
+++ b/Source/Core/QRCode/QRScannerViewModel.swift
@@ -32,8 +32,9 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
 
     private lazy var reader: QRReader = {
         QRReader(onFindClosure: { [weak self] value in
+            guard let self = self else { return }
             DispatchQueue.main.async {
-                self?.loadTransactionRequest(withFormattedId: value)
+                self.loadTransactionRequest(withFormattedId: value)
             }
         })
     }()
@@ -52,7 +53,8 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
         self.loadedIds.append(formattedId)
         self.stopScanning()
         self.onLoadingStateChange?(true)
-        self.verifier.onData(data: formattedId) { result in
+        self.verifier.onData(data: formattedId) { [weak self] result in
+            guard let self = self else { return }
             self.onLoadingStateChange?(false)
             switch result {
             case let .success(data: transactionRequest):

--- a/Source/Core/Websocket/SocketClient.swift
+++ b/Source/Core/Websocket/SocketClient.swift
@@ -129,9 +129,9 @@ public class SocketClient {
         }
         self.reconnectTimer?.invalidate()
         self.reconnectTimer = Timer.scheduledTimer(withTimeInterval: self.reconnectDelay, repeats: false, block: { [weak self] _ in
-            guard let weakself = self, weakself.shouldBeConnected else { return }
-            weakself.connect()
-            weakself.rejoinOpenedChannels()
+            guard let self = self, self.shouldBeConnected else { return }
+            self.connect()
+            self.rejoinOpenedChannels()
         })
     }
 
@@ -143,14 +143,16 @@ public class SocketClient {
 
     private func startHeartbeatTimer() {
         self.heartbeatTimer?.invalidate()
-        self.heartbeatTimer = Timer.scheduledTimer(withTimeInterval: self.heartbeatDelay, repeats: true, block: { _ in
+        self.heartbeatTimer = Timer.scheduledTimer(withTimeInterval: self.heartbeatDelay, repeats: true, block: { [weak self] _ in
+            guard let self = self else { return }
             self.send(topic: "phoenix", event: .heartbeat)
         })
     }
 
     private func resetBufferTimer() {
         self.sendBufferTimer?.invalidate()
-        self.sendBufferTimer = Timer.scheduledTimer(withTimeInterval: self.flushDelay, repeats: true, block: { _ in
+        self.sendBufferTimer = Timer.scheduledTimer(withTimeInterval: self.flushDelay, repeats: true, block: { [weak self] _ in
+            guard let self = self else { return }
             self.flushSendBuffer()
         })
         self.sendBufferTimer?.fire()


### PR DESCRIPTION
Issue/Task Number: 111
Closes #111 

# Overview

This PR adds the missing `[weak self]` that avoid retaining cycles from closures where missing.

# Changes

- Add missing `[weak self]`
- Rename `guard let weakSelf = self else { return }` to `guard let self = self else { return }` following swift `4.2` update
