### PR TITLE
114 improve qr scanner

### DIFF
--- a/OmiseGO.podspec
+++ b/OmiseGO.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OmiseGO'
-  s.version = '1.1.0'
+  s.version = '1.1.1'
   s.license = 'Apache'
   s.summary = 'The OmiseGO iOS SDK allows developers to easily interact with a node of the OmiseGO eWallet.'
   s.homepage = 'https://github.com/omisego/ios-sdk'

--- a/Source/Core/QRCode/QRReader.swift
+++ b/Source/Core/QRCode/QRReader.swift
@@ -9,17 +9,22 @@
 import AVFoundation
 import UIKit
 
+protocol QRReaderDelegate: class {
+    func onDecodedData(decodedData: String)
+    func onUserPermissionChoice(granted: Bool)
+}
+
 class QRReader: NSObject {
     let session = AVCaptureSession()
-    var didReadCode: ((String) -> Void)!
+    weak var delegate: QRReaderDelegate?
     lazy var previewLayer: AVCaptureVideoPreviewLayer = {
         AVCaptureVideoPreviewLayer(session: self.session)
     }()
 
     private let sessionQueue: DispatchQueue = DispatchQueue(label: "serial queue")
 
-    init(onFindClosure: @escaping ((String) -> Void)) {
-        self.didReadCode = onFindClosure
+    init(delegate: QRReaderDelegate?) {
+        self.delegate = delegate
         super.init()
         self.sessionQueue.async {
             self.configureReader()
@@ -62,9 +67,23 @@ class QRReader: NSObject {
         }
     }
 
-    class func isAvailable() -> Bool {
-        guard let captureDevice = AVCaptureDevice.default(for: .video) else { return false }
-        return (try? AVCaptureDeviceInput(device: captureDevice)) != nil
+    func isAvailable() -> Bool {
+        guard AVCaptureDevice.default(for: .video) != nil else { return false }
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        switch status {
+        case .authorized:
+            return true
+        case .restricted, .denied:
+            return false
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video, completionHandler: { [weak self] granted in
+                guard let self = self else { return }
+                DispatchQueue.main.async {
+                    self.delegate?.onUserPermissionChoice(granted: granted)
+                }
+            })
+            return true
+        }
     }
 }
 
@@ -79,7 +98,9 @@ extension QRReader: AVCaptureMetadataOutputObjectsDelegate {
                 metadataObject.type == AVMetadataObject.ObjectType.qr,
                 let decodedData = metadataObject.stringValue
             else { return }
-            self.didReadCode(decodedData)
+            DispatchQueue.main.async {
+                self.delegate?.onDecodedData(decodedData: decodedData)
+            }
         }
     }
 }

--- a/Source/Core/QRCode/QRReader.swift
+++ b/Source/Core/QRCode/QRReader.swift
@@ -40,17 +40,25 @@ class QRReader: NSObject {
         self.session.commitConfiguration()
     }
 
-    func startScanning() {
+    func startScanning(onStart: (() -> Void)? = nil) {
         self.sessionQueue.async {
-            guard !self.session.isRunning else { return }
+            guard !self.session.isRunning else {
+                onStart?()
+                return
+            }
             self.session.startRunning()
+            onStart?()
         }
     }
 
-    func stopScanning() {
+    func stopScanning(onStop: (() -> Void)? = nil) {
         self.sessionQueue.async {
-            guard self.session.isRunning else { return }
+            guard self.session.isRunning else {
+                onStop?()
+                return
+            }
             self.session.stopRunning()
+            onStop?()
         }
     }
 

--- a/Source/Core/QRCode/QRScannerViewController.swift
+++ b/Source/Core/QRCode/QRScannerViewController.swift
@@ -93,6 +93,18 @@ public class QRScannerViewController: UIViewController {
         show ? self.loadingView.showLoading() : self.loadingView.hideLoading()
     }
 
+    /// Manually start the capture.
+    /// Use this method if you want to restart the capture after it has been stoped
+    public func startCapture() {
+        self.viewModel.startScanning()
+    }
+
+    /// Manually stop the capture.
+    /// Use this method if you want to stop the camera capture
+    public func stopCapture() {
+        self.viewModel.stopScanning()
+    }
+
     private func setupUIWithCancelButtonTitle(_ cancelButtonTitle: String) {
         self.view.backgroundColor = .black
         let qrScannerView = QRScannerView(frame: self.view.frame,

--- a/Source/Core/QRCode/QRScannerViewController.swift
+++ b/Source/Core/QRCode/QRScannerViewController.swift
@@ -10,6 +10,10 @@ import UIKit
 
 /// The delegate that will receive events from the QRScannerViewController
 public protocol QRScannerViewControllerDelegate: class {
+    /// This is called upon the decision of user to either accept or decline the camera permissions.
+    ///
+    /// - Parameter granted: True if the user allowed the app to use the camera, false otherwise.
+    func userDidChoosePermission(granted: Bool)
     /// Called when the user tap on the cancel button.
     /// Note that the view controller is not automatically dismissed when the user tap on cancel.
     ///
@@ -58,14 +62,19 @@ public class QRScannerViewController: UIViewController {
     }
 
     func configureViewModel() {
-        self.viewModel.onLoadingStateChange = { isLoading in
-            self.toggleLoadingOverlay(show: isLoading)
+        self.viewModel.onLoadingStateChange = { [weak self] isLoading in
+            self?.toggleLoadingOverlay(show: isLoading)
         }
-        self.viewModel.onGetTransactionRequest = { transactionRequest in
+        self.viewModel.onGetTransactionRequest = { [weak self] transactionRequest in
+            guard let self = self else { return }
             self.delegate?.scannerDidDecode(scanner: self, transactionRequest: transactionRequest)
         }
-        self.viewModel.onError = { error in
+        self.viewModel.onError = { [weak self] error in
+            guard let self = self else { return }
             self.delegate?.scannerDidFailToDecode(scanner: self, withError: error)
+        }
+        self.viewModel.onUserPermissionChoice = { [weak self] granted in
+            self?.delegate?.userDidChoosePermission(granted: granted)
         }
     }
 

--- a/Source/Core/QRCode/QRScannerViewController.swift
+++ b/Source/Core/QRCode/QRScannerViewController.swift
@@ -76,11 +76,11 @@ public class QRScannerViewController: UIViewController {
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.viewModel.startScanning()
+        self.viewModel.startScanning(onStart: nil)
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
-        self.viewModel.stopScanning()
+        self.viewModel.stopScanning(onStop: nil)
         super.viewWillDisappear(animated)
     }
 
@@ -95,14 +95,20 @@ public class QRScannerViewController: UIViewController {
 
     /// Manually start the capture.
     /// Use this method if you want to restart the capture after it has been stoped
-    public func startCapture() {
-        self.viewModel.startScanning()
+    /// This is asynchronous and a completion closure can be provided
+    ///
+    /// - Parameter onStart: A completion closure that will be called when the scanner is started
+    public func startCapture(onStart: (() -> Void)? = nil) {
+        self.viewModel.startScanning(onStart: onStart)
     }
 
     /// Manually stop the capture.
     /// Use this method if you want to stop the camera capture
-    public func stopCapture() {
-        self.viewModel.stopScanning()
+    /// This is asynchronous and a completion closure can be provided
+    ///
+    /// - Parameter onStart: A completion closure that will be called when the scanner is stoped
+    public func stopCapture(onStop: (() -> Void)? = nil) {
+        self.viewModel.stopScanning(onStop: onStop)
     }
 
     private func setupUIWithCancelButtonTitle(_ cancelButtonTitle: String) {

--- a/Source/Core/QRCode/QRScannerViewModel.swift
+++ b/Source/Core/QRCode/QRScannerViewModel.swift
@@ -59,6 +59,7 @@ class QRScannerViewModel: QRScannerViewModelProtocol {
             switch result {
             case let .success(data: transactionRequest):
                 self.onGetTransactionRequest?(transactionRequest)
+                self.loadedIds = self.loadedIds.filter({ $0 != formattedId })
             case let .fail(error: error):
                 self.startScanning()
                 self.onError?(error)

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Tests/Core/QRCodeTests/QRReaderTests.swift
+++ b/Tests/Core/QRCodeTests/QRReaderTests.swift
@@ -12,13 +12,27 @@ import XCTest
 
 class QRReaderTest: XCTestCase {
     func testCallbackIsCalled() {
-        let reader = TestQRReader { value in
-            XCTAssertEqual(value, "123")
-        }
+        let e = self.expectation(description: "calls delegate when decoding data")
+        let delegate = DummyQRReaderDelegate(ex: e)
+        let reader = TestQRReader(delegate: delegate)
         reader.mockValueFound(value: "123")
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(delegate.decodedData, "123")
+    }
+}
+
+class DummyQRReaderDelegate: QRReaderDelegate {
+    let e: XCTestExpectation
+    var decodedData: String?
+
+    init(ex: XCTestExpectation) {
+        self.e = ex
     }
 
-    func testIsAvailable() {
-        XCTAssertFalse(QRReader.isAvailable())
+    func onDecodedData(decodedData: String) {
+        self.decodedData = decodedData
+        self.e.fulfill()
     }
+
+    func onUserPermissionChoice(granted _: Bool) {}
 }

--- a/Tests/Core/QRCodeTests/QRScannerViewControllerTests.swift
+++ b/Tests/Core/QRCodeTests/QRScannerViewControllerTests.swift
@@ -85,4 +85,16 @@ class QRScannerViewControllerTest: FixtureTestCase {
         self.sut.viewWillLayoutSubviews()
         XCTAssertTrue(self.mockViewModel.didUpdateQRReaderPreviewLayer)
     }
+
+    func testStartCapture() {
+        XCTAssertFalse(self.mockViewModel.didStartScanning)
+        self.sut.startCapture()
+        XCTAssertTrue(self.mockViewModel.didStartScanning)
+    }
+
+    func testStopCapture() {
+        XCTAssertFalse(self.mockViewModel.didStopScanning)
+        self.sut.stopCapture()
+        XCTAssertTrue(self.mockViewModel.didStopScanning)
+    }
 }

--- a/Tests/Core/QRCodeTests/QRScannerViewModelTests.swift
+++ b/Tests/Core/QRCodeTests/QRScannerViewModelTests.swift
@@ -13,48 +13,60 @@ class QRScannerViewModelTest: FixtureTestCase {
     func testCallsOnGetTransactionRequestWhenDecodingATransactionRequest() {
         let exp = expectation(description: "Calls onGetTransactionRequest when scanning a valid QRCode")
         let verifier = TestQRVerifier(success: true)
-        let stub = QRScannerViewModel(verifier: verifier)
-        stub.onGetTransactionRequest = { transactionRequest in
+        let sut = QRScannerViewModel(verifier: verifier)
+        sut.onGetTransactionRequest = { transactionRequest in
             defer { exp.fulfill() }
             XCTAssertNotNil(transactionRequest)
         }
-        stub.loadTransactionRequest(withFormattedId: "|123")
+        sut.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testCallsOnErrorWithTheAPIErrorWhenFailingToDecodeATransactionRequest() {
         let exp = expectation(description: "Calls onError when scanning a valid QRCode with an invalid transaction request")
         let verifier = TestQRVerifier(success: false)
-        let stub = QRScannerViewModel(verifier: verifier)
-        stub.onError = { error in
+        let sut = QRScannerViewModel(verifier: verifier)
+        sut.onError = { error in
             defer { exp.fulfill() }
             XCTAssertNotNil(error)
             XCTAssertEqual(error.message, "test")
         }
-        stub.loadTransactionRequest(withFormattedId: "|123")
+        sut.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testDoesntCallWithTheSameIdTwiceIfCallFailed() {
         let exp = expectation(description: "Doesn't call API with the same id twice if the previous call failed")
         let verifier = TestQRVerifier(success: false)
-        let stub = QRScannerViewModel(verifier: verifier)
-        stub.onError = { error in
+        let sut = QRScannerViewModel(verifier: verifier)
+        sut.onError = { error in
             defer { exp.fulfill() }
-            XCTAssert(stub.loadedIds.contains("|123"))
+            XCTAssert(sut.loadedIds.contains("|123"))
             XCTAssertNotNil(error)
-            stub.loadTransactionRequest(withFormattedId: "|123")
+            sut.loadTransactionRequest(withFormattedId: "|123")
         }
-        stub.loadTransactionRequest(withFormattedId: "|123")
+        sut.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testCanDecodeAValidIdMultipleTimes() {
+        let verifier = TestQRVerifier(success: true)
+        let sut = QRScannerViewModel(verifier: verifier)
+        var counter = 0
+        sut.onGetTransactionRequest = { _ in
+            counter += 1
+        }
+        sut.loadTransactionRequest(withFormattedId: "123")
+        sut.loadTransactionRequest(withFormattedId: "123")
+        XCTAssertEqual(counter, 2)
     }
 
     func testCallsOnLoadingStateChangeWhenRequesting() {
         let exp = expectation(description: "Calls onGetTransactionRequest when scanning a valid QRCode")
         let verifier = TestQRVerifier(success: true)
-        let stub = QRScannerViewModel(verifier: verifier)
+        let sut = QRScannerViewModel(verifier: verifier)
         var counter = 0
-        stub.onLoadingStateChange = { loading in
+        sut.onLoadingStateChange = { loading in
             if counter == 0 {
                 XCTAssert(loading)
                 counter += 1
@@ -63,7 +75,7 @@ class QRScannerViewModelTest: FixtureTestCase {
                 exp.fulfill()
             }
         }
-        stub.loadTransactionRequest(withFormattedId: "|123")
+        sut.loadTransactionRequest(withFormattedId: "|123")
         waitForExpectations(timeout: 1, handler: nil)
     }
 }

--- a/Tests/Core/QRCodeTests/QRScannerViewModelTests.swift
+++ b/Tests/Core/QRCodeTests/QRScannerViewModelTests.swift
@@ -50,14 +50,20 @@ class QRScannerViewModelTest: FixtureTestCase {
     }
 
     func testCanDecodeAValidIdMultipleTimes() {
+        let exp = expectation(description: "Can decode a valid Id multiple times")
+        exp.expectedFulfillmentCount = 2
         let verifier = TestQRVerifier(success: true)
         let sut = QRScannerViewModel(verifier: verifier)
         var counter = 0
         sut.onGetTransactionRequest = { _ in
             counter += 1
+            exp.fulfill()
+            if counter < 2 {
+                sut.loadTransactionRequest(withFormattedId: "|123")
+            }
         }
-        sut.loadTransactionRequest(withFormattedId: "123")
-        sut.loadTransactionRequest(withFormattedId: "123")
+        sut.loadTransactionRequest(withFormattedId: "|123")
+        waitForExpectations(timeout: 5, handler: nil)
         XCTAssertEqual(counter, 2)
     }
 

--- a/Tests/Core/TestMocks/TestQRReader.swift
+++ b/Tests/Core/TestMocks/TestQRReader.swift
@@ -56,11 +56,11 @@ class TestQRViewModel: QRScannerViewModelProtocol {
 
     var onError: OnErrorClosure?
 
-    func startScanning() {
+    func startScanning(onStart _: (() -> Void)?) {
         self.didStartScanning = true
     }
 
-    func stopScanning() {
+    func stopScanning(onStop _: (() -> Void)?) {
         self.didStopScanning = true
     }
 

--- a/Tests/Core/TestMocks/TestQRReader.swift
+++ b/Tests/Core/TestMocks/TestQRReader.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class TestQRReader: QRReader {
     func mockValueFound(value: String) {
-        self.didReadCode(value)
+        self.delegate?.onDecodedData(decodedData: value)
     }
 }
 
@@ -40,6 +40,8 @@ class TestQRVCDelegate: QRScannerViewControllerDelegate {
         self.error = error
         self.asyncExpectation?.fulfill()
     }
+
+    func userDidChoosePermission(granted _: Bool) {}
 }
 
 import AVFoundation
@@ -53,6 +55,8 @@ class TestQRViewModel: QRScannerViewModelProtocol {
     var onLoadingStateChange: LoadingClosure?
 
     var onGetTransactionRequest: OnGetTransactionRequestClosure?
+
+    var onUserPermissionChoice: ((Bool) -> Void)?
 
     var onError: OnErrorClosure?
 

--- a/documentation/client.md
+++ b/documentation/client.md
@@ -390,6 +390,10 @@ if let vc = QRScannerViewController(delegate: self, verifier: verifier, cancelBu
 The `QRScannerViewControllerDelegate` offers the following interface:
 
 ```swift
+func userDidChoosePermission(granted: Bool) {
+    // Handle wether the user allowed the app to access the camera or not
+}
+
 func scannerDidCancel(scanner: QRScannerViewController) {
     // Handle tap on cancel button: Typically dismiss the scanner
 }

--- a/documentation/client.md
+++ b/documentation/client.md
@@ -391,7 +391,7 @@ The `QRScannerViewControllerDelegate` offers the following interface:
 
 ```swift
 func userDidChoosePermission(granted: Bool) {
-    // Handle wether the user allowed the app to access the camera or not
+    // Handle whether the user allowed the app to access the camera or not
 }
 
 func scannerDidCancel(scanner: QRScannerViewController) {


### PR DESCRIPTION
Issue/Task Number: 114
Closes #114 
 
# Overview

This PR adds the `startCapture` and `stopCapture` methods on `QRScannerViewController` in order to manually start or stop the camera capture.
Also adds a new delegate method to know if the user accepted or declined the camera permissions.

This is necessary for the new changes currently in progress on the Point Of Sale applications.

# Changes

- Add `startCapture` and `stopCapture` 
- Don't blacklist ids that have been loaded successfully
- Refactor `QRReader` by introducing a delegate with a new method `onUserPermissionChoice`
- Add `func userDidChoosePermission(granted: Bool)` to the existing `QRScannerViewControllerDelegate`