### PR TITLE
Update reset password with new params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.0)
-    activesupport (4.2.11)
+    activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -45,7 +45,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     escape (0.0.4)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -71,7 +71,7 @@ GEM
     nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
-    octokit (4.13.0)
+    octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (3.0.3)
     rainbow (3.0.0)

--- a/OmiseGO.xcodeproj/project.pbxproj
+++ b/OmiseGO.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		03E72EDB2124177E0060E1D7 /* LoginParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDA2124177E0060E1D7 /* LoginParams.swift */; };
 		03E72EDD212424B00060E1D7 /* AuthenticationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */; };
 		03E72EDF2124312C0060E1D7 /* AuthenticationTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */; };
+		03E93809225606810012A92A /* UserResetPasswordParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E93808225606810012A92A /* UserResetPasswordParamsTests.swift */; };
 		03F2D500212436BB00BC65BB /* LoginFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */; };
 		03F827462150CA7100BD05D6 /* WalletListForAccountParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */; };
 		03F827482150F45E00BD05D6 /* Account+Admin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F827472150F45E00BD05D6 /* Account+Admin.swift */; };
@@ -396,6 +397,7 @@
 		03E72EDA2124177E0060E1D7 /* LoginParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginParams.swift; sourceTree = "<group>"; };
 		03E72EDC212424B00060E1D7 /* AuthenticationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationToken.swift; sourceTree = "<group>"; };
 		03E72EDE2124312C0060E1D7 /* AuthenticationTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenTests.swift; sourceTree = "<group>"; };
+		03E93808225606810012A92A /* UserResetPasswordParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResetPasswordParamsTests.swift; sourceTree = "<group>"; };
 		03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFixtureTests.swift; sourceTree = "<group>"; };
 		03F827452150CA7100BD05D6 /* WalletListForAccountParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletListForAccountParams.swift; sourceTree = "<group>"; };
 		03F827472150F45E00BD05D6 /* Account+Admin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+Admin.swift"; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 				032CEDC2211D3D5300E44445 /* RequestFixtureTest.swift */,
 				03F2D4FF212436BB00BC65BB /* LoginFixtureTests.swift */,
 				0380AAEA212D311B006B2193 /* SignupFixtureTests.swift */,
+				03E93808225606810012A92A /* UserResetPasswordParamsTests.swift */,
 			);
 			path = FixtureTests;
 			sourceTree = "<group>";
@@ -1300,6 +1303,7 @@
 				032CEE3D211D3D5300E44445 /* WalletLiveTests.swift in Sources */,
 				032CEE29211D3D5300E44445 /* UserFixtureTests.swift in Sources */,
 				032CEE26211D3D5300E44445 /* ClientCredentialTests.swift in Sources */,
+				03E93809225606810012A92A /* UserResetPasswordParamsTests.swift in Sources */,
 				03AB7ED3214BC04D00C80D8E /* AdminCredentialTests.swift in Sources */,
 				03AB7ED5214BC04D00C80D8E /* FixtureAdminTestCase.swift in Sources */,
 				032CEDD0211D3D5300E44445 /* QRScannerViewTests.swift in Sources */,

--- a/Source/Admin/API/AdminConfiguration.swift
+++ b/Source/Admin/API/AdminConfiguration.swift
@@ -11,7 +11,7 @@ public struct AdminConfiguration: Configuration {
     /// The current SDK version
     let apiVersion: String = "1"
 
-    /// The base URL for the wallet api endpoints:
+    /// The base URL for the eWallet APIs:
     /// When initializing the HTTPAPI, this needs to be an http(s) url
     /// When initializing the SocketClient, this needs to be a ws(s) url
     let baseAPIURL: String

--- a/Source/Admin/API/AdminConfiguration.swift
+++ b/Source/Admin/API/AdminConfiguration.swift
@@ -11,9 +11,10 @@ public struct AdminConfiguration: Configuration {
     /// The current SDK version
     let apiVersion: String = "1"
 
-    /// The base URL of the wallet server:
+    /// The base URL for the wallet api endpoints:
     /// When initializing the HTTPAPI, this needs to be an http(s) url
     /// When initializing the SocketClient, this needs to be a ws(s) url
+    let baseAPIURL: String
     let baseURL: String
     var credentials: Credential
     let debugLog: Bool
@@ -28,7 +29,8 @@ public struct AdminConfiguration: Configuration {
     ///   - authenticationToken: The authentication token of the current user
     ///   - debugLog: Enable or not SDK console logs
     public init(baseURL: String, credentials: AdminCredential = AdminCredential(), debugLog: Bool = false) {
-        self.baseURL = baseURL + "/api/admin"
+        self.baseURL = baseURL
+        self.baseAPIURL = baseURL + "/api/admin"
         self.credentials = credentials
         self.debugLog = debugLog
     }

--- a/Source/Client/API/ClientConfiguration.swift
+++ b/Source/Client/API/ClientConfiguration.swift
@@ -11,9 +11,10 @@ public struct ClientConfiguration: Configuration {
     /// The current SDK version
     let apiVersion: String = "1"
 
-    /// The base URL of the wallet server:
+    /// The base URL for the wallet api endpoints:
     /// When initializing the HTTPAPI, this needs to be an http(s) url
     /// When initializing the SocketClient, this needs to be a ws(s) url
+    let baseAPIURL: String
     let baseURL: String
     var credentials: Credential
     let debugLog: Bool
@@ -28,7 +29,8 @@ public struct ClientConfiguration: Configuration {
     ///   - authenticationToken: The authentication token of the current user
     ///   - debugLog: Enable or not SDK console logs
     public init(baseURL: String, credentials: ClientCredential, debugLog: Bool = false) {
-        self.baseURL = baseURL + "/api/client"
+        self.baseURL = baseURL
+        self.baseAPIURL = baseURL + "/api/client"
         self.credentials = credentials
         self.debugLog = debugLog
     }

--- a/Source/Client/Models/UserResetPasswordParams.swift
+++ b/Source/Client/Models/UserResetPasswordParams.swift
@@ -10,30 +10,50 @@
 public struct UserResetPasswordParams {
     /// The email of the user
     public let email: String
-    /// The URL where the user will be taken when clicking the link in the email
-    public let redirectUrl: String
+    /// The URL of the link that the user will receive by email.
+    /// In most cases this should be the default URL, only override if you
+    /// are building your custom system
+    public let resetPasswordURL: String
+    /// The default reset password page will try to redirect the user to this forwardURL if present.
+    /// If omitted or invalid, the user will be able to reset his password on the default page.
+    /// You can use this URL if you want the default page to open your app with it's scheme for example.
+    public let forwardURL: String?
+
+    static let defaultResetPasswordPath = "/client/reset_password?email={email}&token={token}"
 
     /// Initialize the params used to request a password reset for the user
     ///
     /// - Parameters:
     ///   - email: The email of the user
-    ///   - redirectUrl: The URL where the user will be taken when clicking the link in the email
+    ///   - resetPasswordURL: The URL of the link that the user will receive by email.
+    /// In most cases, you'll want to use the URL from defaultResetPasswordURL(forClient:)
+    ///   - forwardURL: The default reset password page will try to redirect the user to this forwardURL if present.
+    /// If omitted or invalid, the user will be able to reset his password on the default page.
+    /// You can use this URL if you want the default page to open your app with it's scheme for example.
     public init(email: String,
-                redirectUrl: String) {
+                resetPasswordURL: String,
+                forwardURL: String? = nil) {
         self.email = email
-        self.redirectUrl = redirectUrl
+        self.resetPasswordURL = resetPasswordURL
+        self.forwardURL = forwardURL
+    }
+
+    public static func defaultResetPasswordURL(forClient client: HTTPClientAPI) -> String {
+        return client.config.baseURL + self.defaultResetPasswordPath
     }
 }
 
 extension UserResetPasswordParams: APIParameters {
     private enum CodingKeys: String, CodingKey {
         case email
-        case redirectUrl = "redirect_url"
+        case resetPasswordURL = "reset_password_url"
+        case forwardURL = "forward_url"
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(email, forKey: .email)
-        try container.encode(redirectUrl, forKey: .redirectUrl)
+        try container.encode(resetPasswordURL, forKey: .resetPasswordURL)
+        try container.encodeIfPresent(forwardURL, forKey: .forwardURL)
     }
 }

--- a/Source/Core/API/Configuration.swift
+++ b/Source/Core/API/Configuration.swift
@@ -10,9 +10,11 @@
 protocol Configuration {
     /// The current SDK version
     var apiVersion: String { get }
-    /// The base URL of the wallet server:
+    /// The base URL for the wallet api endpoints:
     /// When initializing the HTTPAPI, this needs to be an http(s) url
     /// When initializing the SocketClient, this needs to be a ws(s) url
+    var baseAPIURL: String { get }
+    /// The base URL
     var baseURL: String { get }
     /// The credential object containing the authentication info if needed
     var credentials: Credential { get set }

--- a/Source/Core/API/HTTPAPI.swift
+++ b/Source/Core/API/HTTPAPI.swift
@@ -47,6 +47,10 @@ public class HTTPAPI {
                 performCallback {
                     callback?(.failure(.other(error: error)))
                 }
+            @unknown default:
+                performCallback {
+                    callback?(.fail(error: OMGError.other(error: error)))
+                }
             }
         } catch _ {
             self.performCallback {

--- a/Source/Core/API/RequestBuilder.swift
+++ b/Source/Core/API/RequestBuilder.swift
@@ -15,7 +15,7 @@ final class RequestBuilder {
     }
 
     func buildHTTPURLRequest(withEndpoint endpoint: APIEndpoint) throws -> URLRequest {
-        guard let requestURL = URL(string: self.configuration.baseURL)?.appendingPathComponent(endpoint.path) else {
+        guard let requestURL = URL(string: self.configuration.baseAPIURL)?.appendingPathComponent(endpoint.path) else {
             throw OMGError.configuration(message: "Invalid base url")
         }
 
@@ -37,7 +37,7 @@ final class RequestBuilder {
     }
 
     func buildWebsocketRequest() throws -> URLRequest {
-        guard let url = URL(string: self.configuration.baseURL + "/socket") else {
+        guard let url = URL(string: self.configuration.baseAPIURL + "/socket") else {
             throw OMGError.configuration(message: "Invalid base url")
         }
 

--- a/Tests/Client/FixtureTests/UserResetPasswordParamsTests.swift
+++ b/Tests/Client/FixtureTests/UserResetPasswordParamsTests.swift
@@ -1,0 +1,20 @@
+//
+//  UserResetPasswordParamsTests.swift
+//  Tests
+//
+//  Created by Mederic Petit on 4/4/19.
+//  Copyright © 2019 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+import XCTest
+
+class UserResetPasswordParamsTests: XCTestCase {
+    func testDefaultResetPasswordURL() {
+        let credentials = ClientCredential(apiKey: "apiKey")
+        let config = ClientConfiguration(baseURL: "https://example.com", credentials: credentials)
+        let httpClient = HTTPClientAPI(config: config)
+        let url = UserResetPasswordParams.defaultResetPasswordURL(forClient: httpClient)
+        XCTAssertEqual(url, "https://example.com/client/reset_password?email={email}&token={token}")
+    }
+}

--- a/Tests/Core/CodingTests/EncodeTests.swift
+++ b/Tests/Core/CodingTests/EncodeTests.swift
@@ -667,12 +667,14 @@ class EncodeTests: XCTestCase {
     func testResetPasswordParamsEncoding() {
         do {
             let resetPasswordParams = UserResetPasswordParams(email: "email@example.com",
-                                                              redirectUrl: "xxx")
+                                                              resetPasswordURL: "resetPasswordURL",
+                                                              forwardURL: "forwardURL")
             let encodedData = try self.encoder.encode(resetPasswordParams)
             XCTAssertEqual(String(data: encodedData, encoding: .utf8)!, """
                 {
                     "email":"email@example.com",
-                    "redirect_url":"xxx"
+                    "forward_url": "forwardURL",
+                    "reset_password_url":"resetPasswordURL"
                 }
             """.uglifiedEncodedString())
         } catch let thrownError {

--- a/Tests/Core/Helpers/StubGenerator.swift
+++ b/Tests/Core/Helpers/StubGenerator.swift
@@ -512,9 +512,10 @@ class StubGenerator {
 
     class func resetPasswordParams(
         email: String = "email@example.com",
-        redirectURL: String = "http://localhost:4000"
+        resetPasswordURL: String = "http://localhost:4000/client/reset_password?email={email}&token={token}",
+        forwardURL: String = "my-app://reset_password?email={email}&token={token}"
     ) -> UserResetPasswordParams {
-        return UserResetPasswordParams(email: email, redirectUrl: redirectURL)
+        return UserResetPasswordParams(email: email, resetPasswordURL: resetPasswordURL, forwardURL: forwardURL)
     }
 
     class func updatePasswordParams(

--- a/Tests/Core/TestMocks/TestConfiguration.swift
+++ b/Tests/Core/TestMocks/TestConfiguration.swift
@@ -11,6 +11,8 @@
 struct TestConfiguration: Configuration {
     let apiVersion: String = "1"
 
+    let baseAPIURL: String
+
     let baseURL: String
 
     var credentials: Credential
@@ -19,6 +21,7 @@ struct TestConfiguration: Configuration {
 
     init(baseURL: String = "http://localhost:4000", credentials: TestCredential = TestCredential(authenticated: true)) {
         self.baseURL = baseURL
+        self.baseAPIURL = baseURL + "/api"
         self.credentials = credentials
     }
 }

--- a/documentation/client.md
+++ b/documentation/client.md
@@ -459,12 +459,14 @@ User.resetPassword(using: client, params: params) { result in
 Where `params` is a `UserResetPasswordParams` struct constructed using:
 
 - `email`: The email of the user (ie: email@example.com)
-- `redirectURL`: A redirect URL that will be built on the server by replacing the `{email}` and `{token}` params.
+- `reset_password_url`: The URL of the link that the user will receive by email.
+  In most cases this should be the default URL, only override if you are building your custom system.
+  The default URL can be retrieved using the `defaultResetPasswordURL(forClient:)` function
+- `forward_url`: The default reset password page will try to redirect the user to this forwardURL if present.
+  If omitted or invalid, the user will be able to reset his password on the default page.
+  You can use this URL if you want the default page to open your app with it's scheme for example.
 
-For example, if you provide this url: `my-app-scheme-uri://user/reset_password?email={email}&token={token}`, the user will receive a link by email that will look like this: `my-app-scheme-uri://user/reset_password?email=email@example.com&token=XXXXXXXXXXXXXXXXXXXXXX`.
-You can then handle the params passed to your application upon launch from this deep link and pass them to the `User.updatePassword` method.
-
-> This url needs to be whitelisted on the eWallet configuration page using the `Redirect URL Prefixes` config before being used.
+> These urls needs to be whitelisted on the eWallet configuration page using the `Redirect URL Prefixes` config before being used.
 
 #### Update password
 


### PR DESCRIPTION
Issue/Task Number: 123
closes #123 

# Overview

This PR updates the reset password params to support the new `forward_url` attr.

# Changes

- Add `forward_url` to ResetPasswordParams
- Rename `redirect_url` to `reset_password_url`

> Note: based on `122-swift5` until merged
